### PR TITLE
Update EEP 49 (eep-0049.md)

### DIFF
--- a/eeps/eep-0049.md
+++ b/eeps/eep-0049.md
@@ -1135,13 +1135,157 @@ The Elixir approach is fairly comprehensive, and rather powerful. Rather
 than handling success or errors, it generalizes over pattern matching as
 a whole.
 
-In the end though, it ends up not specifically doing that much in terms
-of error handling.
+To explore bringing these semantics into the current proposed construct,
+we will use the `<-` operator from list comprehensions to mean "match
+the whole pattern or exit the block". So instead of
 
-The current proposal really wanted a mechanism more appropriate and dedicated
-to value-based error handling than straight up pattern matching. The `<-`
-operator (for example) could be brought in as an extension supporting more
-generalized pattern matching, but is currently not in scope.
+    begin
+        {X,Y} <~ id({ok, {X,Y}})
+        ...
+    end
+
+We would have to write:
+
+    begin
+        {ok, {X,Y}} <- id({ok, {X,Y}})
+        ...
+    end
+
+While this mechanism is fine to handle skipping pattern, it has some
+problematic weaknesses in the context of error handling.
+
+One example of this could be taken from the OTP pull request that adds
+new return value to packet reading based on inet options:
+https://github.com/erlang/otp/pull/1950
+
+This PR adds a possible value for packet reception to the current form:
+
+    {ok, {PeerIP, PeerPort, Data}}
+
+To ask make it possible to alternatively get:
+
+    {ok, {PeerIP, PeerPort, AncData, Data}}
+
+Based on socket options set earlier. So let’s put it in context for the
+current proposal:
+
+    begin
+        {X,Y} <~ id({ok, {X,Y}}),
+        {PeerIP, PeerPort, Data} <~ gen_udp:recv(...),
+        ...
+    end
+
+If `AncData` is received, an exception is raised: the value was not an
+error but didn’t have the shape or type expected for the successful
+pattern to match. Errors are still returned properly by exiting the
+`begin ... end` block, and we ensure correctness in what we handle and
+return.
+
+However, had we used this generalized form:
+
+    begin
+        {ok, {X,Y}} <- id({ok, {X,Y}}),
+        {ok, {PeerIP, PeerPort, Data}} <- gen_udp:recv(...),
+        ...
+    end
+
+Since the `<-` operator would force a return on any non-matching value,
+the whole expression, if the socket is misconfigured to return
+`AncData`, would return `{ok, {PeerIP, PeerPort, AncData, Data}}` on a
+failure to match.
+
+Basically, an unexpected but good result could be returned from a
+function using the `begin ... end` construct, which would look like a
+success while it was actually a complete failure to match and handle the
+information given.  This is made even more ambiguous when data has the
+right shape and type, but a set of bound variables ultimately define
+whether the match succeeds or fails (in the case of a UDP socket,
+returning values that comes from the wrong peer, for example).
+
+In worst cases, It could let raw unformatted data exit a conditional
+pipeline with no way to detect it after the fact, particularly if later
+functions in `begin ... end` apply transformations to text, such as
+anonymizing or sanitizing data. This could be pretty unsafe
+and near impossible to debug well.
+
+Think for example of:
+
+    -spec fetch() -> iodata().
+    fetch() ->
+        begin
+            {ok, B = <<_/binary>>} <- f(),
+            true <- validate(B),
+            {ok, sanitize(B)}
+        end.
+
+If the value returned from `f()` turns out to be a list (say it’s a
+misconfigured socket using `list` instead of `binary` as an option), the
+expression will return early, the `fetch()` function will still return
+`{ok, iodata()}` but you couldn’t know as a caller whether it is the
+transformed data or non-matching content. It would not be obvious to
+most developers either that this could represent a major security risk
+by allowing unexpected data to be seen as clean data.
+
+This specific type of error is in fact possible in Elixir, but no such
+warning appears to have been circulating within its community so far.
+
+It is basically a risky pattern if you want your code to be strict or
+future-proof in the context of error handling. The current proposal, by
+comparison, would raise an exception on unexpected good values, therefore
+preventing ways to sneak such data into your control flow:
+
+    -spec fetch() -> iodata().
+    fetch() ->
+        begin
+            B = <<_/binary>> <~ f(),
+            _ <~ validate(B), % returns ok if valid
+            {ok, sanitize(B)}
+        end.
+
+Here misconfigured sockets won’t result in unchecked data passing trough
+your app.
+
+The only way to give a similar amount of safety to the general pattern
+approach is through an `else` clause which handles all known patterns to
+implicitly exclude all unknown patterns:
+
+    -spec fetch() -> iodata().
+    fetch() ->
+        begin
+            {ok, B = <<_/binary>>} <- f(),
+            true <- validate(B),
+            {ok, sanitize(B)}
+        else
+            {error, _} = E -> E;
+            false -> false
+        end.
+
+This is the solution Elixir uses as well. Unless the clause is mandatory
+(it is not in Elixir), this level of additional matching is purely
+optional; the developer has no obvious incentive to go and handle these
+errors, and if they do, the exception raised will be through a missing
+clause in the `else` section, which will obscure its origin and line
+nubmer.
+
+It would also allow some functions to return unexpected values from
+other ones. In the previous example, `f()` must be allowed to return
+`false` if `validate(B)` may return it. There is no way to separate such
+clauses.
+
+None of these problems exist as long as we normalize the matching
+mechanism on well-defined "good" and "bad" values (`ok | {ok, Term}` and
+`{error, Term}`). This separation between good and bad values allows to
+know what needs to return early without conflicts with what is a valid
+or invalid pattern.
+
+From the moment we decide to pick such values, unwrapping them in
+patterns can make code clearer: `{error, X} <- exp()` would be a pattern
+that can never match by definition, since only good values are allowed
+to go through and all errors return early. Automatically unwrapping good
+values prevents such nonsensical expressions.
+
+These tricky corner cases explain why the `<~` pattern is preferred to
+the general `<-` pattern's semantics in this proposal.
 
 ### Simplifying Chaining an Pipelining ###
 
@@ -1279,6 +1423,46 @@ Aligning with the standard practices in the Erlang language validate
 using `_ <~ Exp` as a pattern suitable for `ok`, and only this pattern
 since it allows to basically match on what would be a non-existing value
 that wouldn't need to be bound in further contexts.
+
+Discussions on earlier drafts of this proposal asked whether it would
+make sense to choose all good values to be those in a tuple starting
+with `ok` (`ok | {ok, _} | {ok, _, _} | ...`), and all error values all
+those starting with error (`{error, _} | {error, _, _} | ...`).
+
+This approach would allow more flexibility on possible error values, but
+would make composition more difficult. Let's take the following three
+function signatures as an example:
+
+    -spec f() -> ok | {error, term()}.
+    -spec g() -> {ok, term()} | {error, term(), term()}.
+    -spec h() -> {ok, term(), [warning()]} | {error, term()}.
+
+If a single `begin ... end` block calls to these as the potential return
+value of a function, the caller now has to have the following type
+specification:
+
+    -spec caller() -> ok | {ok, term()} | {ok, term(), [warning()]}
+                    | {error, term()} | {error, term(), term()}.
+
+As you call more and more functions and compose them together, the
+cross-section of what is a valid returning function grows in complexity
+and may even end up giving more trouble to tools such as Dialyzer.
+
+By comparison, the currently suggested mechanism can never get more
+complex than:
+
+    -spec caller() -> ok | {ok, term()} | {error, term()}.
+
+Or, if we prefer parametrized types:
+
+    -type result(E) :: ok | {error, E}.
+    -type result(R, E) :: {ok, R} | {error, E}.
+
+    -spec caller() -> result(term()) | result(term(), term()).
+
+By restricting the possible patterns (and therefore return values), we
+can ensure better long-term composability and easier understanding of
+various such expressions.
 
 Choosing Exceptions Raised
 --------------------------


### PR DESCRIPTION
Add content on comparisons with Elixir's `with`, and expand on not
supporting all ok- and error-based tuples following community feedback