### PR TITLE
Update EEP-48

### DIFF
--- a/eeps/eep-0048.md
+++ b/eeps/eep-0048.md
@@ -93,7 +93,6 @@ entries on a separate command, completely unrelated from code compilation.
 
 ## Part 2: the "Docs" format ##
 
-
 In both storages, the documentation is written in the exactly same
 format: an Erlang term serialized to binary via `term_to_binary/1`.
 The term may be optionally compressed when serialized and must follow
@@ -103,27 +102,27 @@ the type specification below:
      Anno :: erl_anno:anno(),
      BeamLanguage :: atom(),
      Format :: mime_type(),
-     ModuleDoc :: #{DocLanguage := DocString} | none | hidden,
+     ModuleDoc :: #{DocLanguage := DocValue} | none | hidden,
      Metadata :: map(),
      Docs ::
        [{{Kind, Name, Arity},
          Anno :: erl_anno:anno(),
          Signature :: [binary()],
-         Doc :: #{DocLanguage := DocString} | none | hidden,
+         Doc :: #{DocLanguage := DocValue} | none | hidden,
          Metadata :: map()
         }]} when DocLanguage :: binary(),
-                 DocString :: binary()
+                 DocValue :: binary() | term()
 
 where in the root tuple we have:
 
-  * `Anno` - annotation (line, column, file) of the module documentation
-    or of the definition itself (see `erl_anno`)
+  * `Anno` - annotation (line, column, file) of the definition itself
+    (see `erl_anno`)
 
   * `BeamLanguage` - an atom representing the language, for example:
     `erlang`, `elixir`, `lfe`, `alpaca`, etc
 
   * `Format` - the mime type of the documentation, such as "text/markdown"
-    (see the FAQ for a discussion on this field)
+    or "application/erlang+html" (see the FAQ for a discussion on this field)
 
   * `ModuleDoc` - a map with the documentation language as key, such as
     `<<"en">>` or `<<"pt_BR">>`, and the documentation as a binary value.
@@ -156,10 +155,14 @@ For each entry in `Docs`, we have:
     exclusively for exhibition purposes
 
   * `Doc` - a map with the documentation language as key, such as
-    `<<"en">>` or `<<"pt_BR">>`, and the documentation as a binary value.
-    It may be the atom `none` in case there is no documentation or the
-    atom `hidden` if documentation has been explicitly disabled for this
-    entry
+    `<<"en">>` or `<<"pt_BR">>`, and the documentation as a value.
+    The documentation may either be a binary or any Erlang term,
+    both described by `Format`. If it is an Erlang term, then the
+    `Format` must be "application/erlang+SUFFIX", such as
+    "application/erlang+html" when the documentation is an Erlang
+    representation of an HTML document. The `Doc` may also be the
+    atom `none` in case there is no documentation or the atom `hidden`
+    if documentation has been explicitly disabled for this entry
 
   * `Metadata` - a map of atom keys with any term as value
 
@@ -182,6 +185,9 @@ following metadata keys:
 
   * `since := binary()` - a binary representing the version such entry
     was added, such as `<<"1.3.0">>` or `<<"20.0">>`
+
+  * `edit_url := binary()` - a binary representing a URL to change to
+    change the documentation itself
 
 Any key may be added to Metadata at any time.  Keys that are frequently
 used by the community can be standardized in future versions. 


### PR DESCRIPTION
This introduces the following updates:

  1. Allow the documentation format to be an Erlang term,
  as long as the Format starts with "application/erlang+"

  2. Clarify that the job of `Anno` is to point to the source.
  The `edit_url` metadata has been established to edit
  the docs themselves.