### PR TITLE
Update EEP-54 according to the decision of OTB

### DIFF
--- a/eeps/eep-0054.md
+++ b/eeps/eep-0054.md
@@ -3,7 +3,7 @@
     Type: Standards Track
     Created: 14-Sep-2020
     Erlang-Version: 24
-    Post-History:
+    Post-History: 14-Oct-2020, 27-Nov-2020
 ****
 EEP 54: Provide more information about errors
 ----
@@ -77,35 +77,52 @@ we propose adding an `{error_info,ErrorInfoMap}` tuple to `ExtraInfo`
 in the first element in the stacktrace.
 
 The map `ErrorInfoMap` may contain further information about the error
-or hints on how to handle the error.  Currently, only the optional key
-`cause` has a defined meaning.  If it is exists, its value provides
-additional information about the error.
+or hints on how to handle the error.
 
-To obtain more information about the error, the `format_error/4`
-function in module `Module` can be called to provide additional information about
-the error.
+Currently, three optional keys have a defined meaning:
 
-The arguments for `format_error/4` are `Function`, `Arguments`, the
-exception reason (usually `badarg` for BIF calls), and `ErrorInfoMap`.
+* The value of the key `module` is a module name of a module that
+  can be called to provide additional information about the error.
+  Default is `Module` from the stacktrace entry.
+
+* The value of the key `function` is the name of the function to
+  be called in the module providing the error information. The
+  default name is `format_error`.
+
+* The value of the key `cause`, if it exists, provides additional
+  information about the error.
+
+To obtain more information about the error, the function named by the
+values of the `module` and `function` keys can be called.  Hereafter
+in this document, for brevity we will call that function
+`format_error/2`.
+
+The arguments for `format_error/2` are the exception reason (usually
+`badarg` for BIF calls) and the stacktrace.
 
 Thus, if a call to `element/2` fails with a `badarg` exception and the
 first entry in the stacktrace is:
 
     {erlang,element,[1,no_tuple],[{error_info,ErrorInfoMap}]}
 
-the following call will provide provide additional information about
-the error:
+and assuming that the stacktrace is bound to the variable
+`StackTrace`, the following call will provide provide additional
+information about the error:
 
-    erlang:format_error(element, [1,no_tuple], badarg, ErrorInfoMap)
+    FormatModule = maps:get(module, ErrorInfoMap, erlang),
+    FormatFunction = maps:get(function, ErrorInfoMap, format_error),
+    FormatModule:FormatError(badarg, StackTrace)
 
-The `format_error/4` function should return a map.  For each argument
+The `format_error/2` function should return a map.  For each argument
 that was in error, there should be a map element with the argument number
 as the key (that is, `1` for the first argument, `2` for the second, and so on)
 and a `unicode:chardata()` term as the value.
 
 As an example:
 
-    erlang:format_error(element, [1,no_tuple], badarg, ErrorInfoMap)
+    Args = [1,no_tuple],
+    StackTrace = [{erlang, element, Args, [{error_info,Map}]}],
+    erlang:format_error(badarg, StackTrace)
 
 could return:
 
@@ -113,28 +130,29 @@ could return:
 
 And:
 
-    erlang:format_error(element, [0, b], badarg, ErrorInfo)
+    Args = [0, b],
+    StackTrace = [{erlang, element, Args, [{error_info,Map}]}],
+    erlang:format_error(badarg, Entry)
 
 could return:
 
     #{1 => <<"out of range">>, 2 => <<"not a tuple">>}
 
-Note that the `ErrorInfoMap` term is only to be used by
-`Module:format_error/4`.  It is not to be matched by code in other
-modules.  Note that the `cause` key in the map is optional.  If the
-`cause` key *is* present, the particular value for a particular
-error could change at any time.
+Note that the value for the key `cause`, if present, in the
+`ErrorInfoMap` term is only to be used by `format_error/2`.  The
+actual value for a particular error could change at any time.
 
-The `clause` key will typically only be present when an error occurs
+The `cause` key will typically only be present when an error occurs
 in a BIF that depends on the internal state in the runtime system
 (such as `register/2` or the ETS BIFs), or for BIFs with complex
 arguments (such as `system_flag/2`) that would make it tedious and
 error prone to figure out which argument was in error.
 
-Here is one way that `format_error/4` for the `erlang` module could
+Here is one way that `format_error/2` for the `erlang` module could
 be implemented:
 
-    format_error(F, As, ExceptionReason, ErrorInfoMap) ->
+    format_error(ExceptionReason, [{erlang, F, As, Info} | _]) ->
+        ErrorInfoMap = proplists:get_value(error_info, Info, #{}),
         Cause = maps:get(cause, ErrorInfoMap, none),
         do_format_error(F, As, ExceptionReason, Cause).
 
@@ -209,15 +227,15 @@ determining the extended error information:
   BIF that was called).  No extended error information is returned,
   because the explanation for `system_limit` is sufficiently clear.
 
-* If `element/2` failed, the `format_error/4` function only examines
+* If `element/2` failed, the `format_error/2` function only examines
   the arguments for `element/2`.
 
 * If `list_to_atom/1` raised a `badarg` exception, there is only one
   possible error reason, so there is no need to examine the arguments.
 
-* If `register/2` BIF fails, the value corresponding to the `clause`
+* If `register/2` BIF fails, the value corresponding to the `cause`
   key provides specific error reasons for two of the possible failure
-  reasons.  If the reason is not one of the two, `format_error/4` will
+  reasons.  If the reason is not one of the two, `format_error/2` will
   figure out the other reasons based on the arguments.
 
 
@@ -230,8 +248,9 @@ information by calling `erlang:error(Reason, Arguments, Options)`.
 should be arguments for the calling function, and `Options` should
 be `[{error_info,ErrorInfoMap}]`.
 
-The module that raises the exception should export a `format_error/4`
-function that behaves as described in the previous section.
+The caller of `erlang:error/3` should provide a `format_error/2`
+function (not necessarily with that name if the `ErrorInfoMap` has a
+`function` key) that behaves as described in the previous section.
 
 
 ### Formatting stacktraces
@@ -260,14 +279,10 @@ documentation in the reference implementation for details.
 ### Possible future extensions
 
 Since the `error_info` tuple in the stacktrace contains a map, more
-data could be added to the map.  For example, there could be `module`
-and `function` keys to allow pointing out a `format_error/4` function
-with an arbitrary name.  That could be useful if the compiler were to
-generate extended error information for `badmatch` or
-`function_clause` errors.
+data could be added to the map in future extension of this EEP.
 
-Since the return value of `format_error/4` is a map, additional keys
-in the map could be assigned a meaning in the future.
+Similarly, since the return value of `format_error/2` is a map,
+additional keys in the map could be assigned a meaning in the future.
 
 For example, the value for the key `hint` could be a longer message
 that gives more context or provides concrete advice on how to
@@ -388,11 +403,36 @@ To avoid confusion with the exception reason.
 
 The reason in the `ErrorInfoMap` is not meant to be used for
 programmatically figuring out why an error occurred, but only to be used
-by `Module:format_error/4` to produce a human-readable message.
+by `Module:format_error/2` to produce a human-readable message.
 
 Also, for many BIFs the `cause` key will not be present,
 as the `Module:format/4` function will produce the messages
 based solely on the name of the BIF and its arguments.
+
+
+### How is the `module` key useful?
+
+* In OTP all `format_error/2` functions will be in modules separate
+  from the implementing modules to facilitate reducing the size of OTP
+  in systems with tight storage constraints.  Having the `module`
+  key avoids the need for having a redirecting `format_error/2`
+  function in the implementing module.
+
+* A library or application may want to have a single module that
+  implements `format_error/2` for multiple modules.  For example, in
+  OTP we might have the module `erl_stdlib_errors` that implements
+  `format_error/2` for the modules `binary`, `ets`, `lists`, `maps`,
+  `string`, and `unicode`.
+
+
+
+### How is the `function` key useful?
+
+* A module could already have a function named `format_error/2`.
+
+* In the future we might want to extend the compiler to generate its
+  own `format_error/2` error function to provide more information
+  about `badmatch` or `function_clause` errors.
 
 
 


### PR DESCRIPTION
The OTP Technical Board approved the EEP, but requested a few
changes:

* The optional `module` and `function` keys in the map will point
  the module and function for a `format_error` function.

* The arguments for `format_error` has been simplified to just
  two arguments: The exception reason and the first entry in
  stacktrace.

Taken together, those to changes makes it easy to have one module
with a `format_error/2` that can explain errors for multiple
modules.