### PR TITLE
Update EEP 56

### DIFF
--- a/eeps/eep-0056.md
+++ b/eeps/eep-0056.md
@@ -4,10 +4,10 @@
     Type: Standards Track
     Created: 04-Mar-2021
     Erlang-Version: 25
-    Post-History:
+    Post-History: 08-Mar-2021
     Replaces:
 ****
-EEP 56: Automatic supervisor shutdown triggered by termination of significant childs
+EEP 56: Automatic supervisor shutdown triggered by termination of significant children
 ----
 
 
@@ -16,7 +16,7 @@ Abstract
 ========
 
 This EEP introduces a way of automatically terminating supervisors based
-on the termination of specifically marked significant childs.
+on the termination of specifically marked significant children.
 
 This document is based on the discussion in [OTP-PR 4521][].
 
@@ -53,7 +53,7 @@ can be called truly good, straightforward, or canonical:
   the top supervisor to be blocked until the group supervisor has been shut
   down, so it will not accept other requests until then.
 
-Both of the above approaches suffer from the fact that the childs responsible
+Both of the above approaches suffer from the fact that the children responsible
 for the shutdown have to know things about their surroundings, namely...:
 
 * ... that it is located under a (group) supervisor in the first place. In the
@@ -64,22 +64,22 @@ for the shutdown have to know things about their surroundings, namely...:
 * ... that it may have siblings, and that it is safe to cause their shutdown
   by shutting down the supervisor. From a programmer's perspective, it is not
   obvious just by looking at the supervisor implementation that a certain
-  child may cause a shutdown of the supervisor and all childs, so there is
+  child may cause a shutdown of the supervisor and all children, so there is
   a potential for surprises.
 
 This may be tackled by having a dedicated overseer child that watches the
-other childs and acts according to their behavior. However, this requires
+other children and acts according to their behavior. However, this requires
 considerable boilerplate code for tasks that would be better suited in the
 supervisor. Also, there is the problem that the overseer process must keep
-the list of childs it watches up to date should any of them be restarted,
-either by enabling the childs to register with it on start (for which they
+the list of children it watches up to date should any of them be restarted,
+either by enabling the children to register with it on start (for which they
 in turn must know the overseer process' pid), or asking the supervisor
 for it.
 
-Another approach that is often used is to make the childs responsible for
+Another approach that is often used is to make the children responsible for
 the shutdown of the group supervisor permanent and the supervisor's restart
 intensity to 0. This has the downside that the child will not be restarted
-but cause the supervisor to shut down if it exits abnormally and _could_
+but cause the supervisor to shut down if it exits abnormally but _could_
 be restarted. Another downside to this approach is that it produces error
 messages (crash reports), even if the shutdown is intended.
 
@@ -93,9 +93,9 @@ Rationale
 =========
 
 This EEP provides a means to alleviate the problems outlined in the
-motivation by introducing a way to mark specific childs as `significant`
+motivation by introducing a way to mark specific children as `significant`
 via a new child spec flag, and a way to configure supervisors to shut down
-automatically depending on the exit of significant childs via a new
+automatically depending on the exit of significant children via a new
 supervisor flag.
 
 In order to keep backwards compatibility, the new flags will only be usable
@@ -106,39 +106,47 @@ the supervisor behaves the same as it does to date.
 The new child spec flag is named `significant` with possible values `true` and
 `false`, with `false` being the default.
 
-The new supervisor flag is named `shutdown` with possible values `normal`,
-`any_significant`and `all_significant`, with `normal` being the default.
+The new supervisor flag is named `auto_shutdown` with possible values `never`,
+`any_significant` and `all_significant`, with `never` being the default.
 
 (The proposed names and values are working titles.)
 
-With the supervisor `shutdown` flag set to `normal`, the child spec flag
+With the supervisor `auto_shutdown` flag set to `never`, the child spec flag
 `significant` is ignored, even if present and set to `true`. This is intended
-as a safety means to defend against unwanted breaking of old code.
+as a safety means to defend against unintended automatic shutdowns, for example
+by the exit of a significant child which was added later via
+`supervisor:start_child/2`. As the spec for such a child would not be present
+in the `supervisor:init/1` callback code but somewhere else, debugging such
+unexplained supervisor shutdowns might be difficult.
 
 Otherwise, the following rules apply when a significant child exits _on its
 own_:
 
 * A `permanent` child will always be restarted and not cause the supervisor to
-  shut down, ie the `significant` flag has no meaning for permanent childs.
- * A `transient` child will be restarted (not cause a supervisor shutdown)
-   if it exits abnormally. If it exits normally...
-   * if the supervisor `shutdown` flag is `any_significant`, the supervisor
-     will shut down
-   * if the supervisor `shutdown` flag is `all_significant`, the supervisor
-     will shut down if the child was the last active significant child
+  shut down, ie the `significant` flag has no meaning for permanent children.
+* A `transient` child will be restarted (not cause a supervisor shutdown)
+  if it exits abnormally. If it exits normally...
+  * if the supervisor `auto_shutdown` flag is `any_significant`, the supervisor
+    will shut down
+  * if the supervisor `auto_shutdown` flag is `all_significant`, the supervisor
+    will shut down if the child was the last active significant child
 * A `temporary` child will never be restarted. If it exits normally or
-  abnormally, the same rules as for `transient` childs apply, in regard to
-  the supervisor `shutdown` flag.
+  abnormally, the same rules as for `transient` children apply, in regard to
+  the supervisor `auto_shutdown` flag.
 
-To be clear, the above rules only apply when _significant_ childs exit
-_by themselves_, that is, not when other non-significant childs exit,
+To be clear, the above rules only apply when _significant_ children exit
+_by themselves_, that is, not when other non-significant children exit,
 not as a consequence of being restarted by a sibling's death in the
 `one_for_all` or `rest_for_one` strategies, and not when being terminated
 manually via `supervisor:terminate_child/2`.
 
 The approach proposed here could also be used to the effect of "shutdown when
-empty" by marking _all_ childs as `significant` and setting the supervisor
-`shutdown` flag to `all_significant`.
+empty" by marking _all_ children as `significant` and setting the supervisor
+`auto_shutdown` flag to `all_significant`.
+
+It is worth mentioning that the `simple_one_for_one` strategy poses a special
+case, as it can have only a single child spec that applies to all children.
+That means that either _all_ children are significant ones, or _none_ is.
 
 
 


### PR DESCRIPTION
This update implements suggestions from the eeps mailing list and adds a few paragraphs for clarification:

* Fixed grammar: "childs" --> "children"
* The supervisor flag `shutdown` was renamed to `auto_shutdown`, and the value `normal` to `never`, which should be clearer
* Clarified the purpose of the `never` option for the `auto_shutdown` supervisor flag
* Added a paragraph about significant children in `simple_one_for_one` supervisors