### PR TITLE
eep54: Add general and reason to return map

### DIFF
--- a/eeps/eep-0054.md
+++ b/eeps/eep-0054.md
@@ -118,6 +118,13 @@ that was in error, there should be a map element with the argument number
 as the key (that is, `1` for the first argument, `2` for the second, and so on)
 and a `unicode:chardata()` term as the value.
 
+The atoms `general` and `reason` can also be returned in the map.
+`general` represents a generic error that is not attributed for a specific argument
+(for example badarg of io:format("Hello") when the default device is dead).
+`reason` will tell the error pretty printer to print the returned string instead
+of the error reason. The value pointed to by `general` and `reason` should be
+a `unicode:chardata()` term.
+
 As an example:
 
     Args = [1,no_tuple],
@@ -137,6 +144,16 @@ And:
 could return:
 
     #{1 => <<"out of range">>, 2 => <<"not a tuple">>}
+
+And:
+
+    Args = ["Hello"],
+    StackTrace = [{io, format, Args, [{error_info,Map}]}],
+    erlang:format_error(badarg, Entry)
+
+could return:
+
+    #{general => "the device has terminated"}
 
 Note that the value for the key `cause`, if present, in the
 `ErrorInfoMap` term is only to be used by `format_error/2`.  The
@@ -350,7 +367,17 @@ will fail. That number is too low.  Missing from list are, for
 example, reasons such as the ETS table having been deleted or having
 insufficient access right.
 
+The `general` return key was added in order to allow information
+to be given about the default I/O device in [io:format("hello")][io_format_1].
+It also allows third-party error_report implementations (such as Elixir)
+much more freedom in what they can return.
+
+The `reason` return key was added in order for third-party error_report
+implementations (such as Elixir) to influence what is printed to describe
+the actual error.
+
 [update_counter_4]: http://erlang.org/doc/man/ets.html#update_counter-4
+[io_format_1]: http://erlang.org/doc/man/io.html#format-1
 
 
 


### PR DESCRIPTION
The `general` return key was added in order to allow information
to be given about the default I/O device in [io:format("hello")][io_format_1].
It also allows third-party error_report implementations (such as Elixir)
much more freedom in what they can return.

The `reason` return key was added in order for third-party error_report
implementations (such as Elixir) to influence what is printed to describe
the actual error.

[io_format_1]: http://erlang.org/doc/man/io.html#format-1