### PR TITLE
Update eep-0049 with decisions from OTP Technical Board

### DIFF
--- a/eeps/eep-0049.md
+++ b/eeps/eep-0049.md
@@ -10,13 +10,11 @@ EEP 49: Value-Based Error Handling Mechanisms
 Abstract
 ========
 
-This EEP extends the `begin ... end` expression to make it a construct
-usable for control flow and value-based error handling based on pattern
-matching.
-
-This introduces `begin ... else ... end` along with a new contextual use
-of the `<-` operator to replace or simplify deeply-nested `case ... end`
-expressions, and prevent using exceptions for control flow.
+This EEP introduces the `maybe ... end` expression as a construct
+usable for control flow and value-based error handling based on
+pattern matching. By using this construct, deeply nested `case
+... end` expressions can be avoided or simplified, and the use of
+exception for flow control can be avoided.
 
 Copyright
 =========
@@ -26,39 +24,38 @@ This document has been placed in the public domain.
 Specification
 =============
 
-The current syntax for a `begin ... end` expression is:
+We propose the `maybe ... end` construct which is similar to `begin
+... end` in that it is used to group multiple distinct expression as a
+single block. But there is one important difference in that the
+`maybe` block does not export its variables while `begin` does
+export its variables.
 
-    begin
-        Exprs
-    end
+We propose a new
+type of expressions (denoted `MatchOrReturnExprs`), which are only valid within a
+`maybe ... end` expression:
 
-The expression does not have a restricted scope, and is mostly used to
-group multiple distinct expressions as a single block. We propose a new
-type of expressions (denoted `MatchOrReturnExprs`), only valid within a
-`begin ... end` expression:
-
-    begin
+    maybe
         Exprs | MatchOrReturnExprs
     end
 
 `MatchOrReturnExprs` are defined as having the following form:
 
-    Pattern <- Expr
+    Pattern <~ Expr
 
 This definition means that `MatchOrReturnExprs` are only allowed at the
-top-level of `begin ... end` expressions.
+top-level of `maybe ... end` expressions.
 
-The `<-` operator takes the value return by `Expr` and pattern matches on
+The `<~` operator takes the value returned by `Expr` and pattern matches on
 it against `Pattern`.
 
 If the pattern matches, all variables from `Pattern` are bound in the local
 environment, and the expression is equivalent to a successful `Pattern = Expr`
-call. If the value does not match, the `begin ... end` expression returns the
+call. If the value does not match, the `maybe ... end` expression returns the
 failed expression directly.
 
-A special case exists in which we extend `begin ... end` into the following form:
+A special case exists in which we extend `maybe ... end` into the following form:
 
-    begin
+    maybe
         Exprs | MatchOrReturnExprs
     else
         Pattern -> Exprs;
@@ -77,10 +74,10 @@ happy and unhappy paths.
 
 Given the structure described here, the final expression may look like:
 
-    begin
+    maybe
         Foo = bar(),            % normal exprs still allowed
-        {ok, X} <- f(Foo),
-        [H|T] <- g([1,2,3]),
+        {ok, X} <~ f(Foo),
+        [H|T] <~ g([1,2,3]),
         ...
     else
         {error, Y} ->
@@ -90,17 +87,15 @@ Given the structure described here, the final expression may look like:
     end
 
 Do note that to allow easier pattern matching and more intuitive usage,
-the `<-` operator should have associativity rules lower than `=`, such that:
+the `<~` operator should have associativity rules lower than `=`, such that:
 
-    begin
-        X = [H|T] <- exp()
+    maybe
+        X = [H|T] <~ exp()
     end
 
-is a valid `MatchOrReturnExprs` equivalent to the non-infix form `'<-'('='(X,
-[H|T]), exp())`, since reversing the priorities would give `'='('<-'(X, [H|T]),
+is a valid `MatchOrReturnExprs` equivalent to the non-infix form `'<~'('='(X,
+[H|T]), exp())`, since reversing the priorities would give `'='('<~'(X, [H|T]),
 exp())`, which would create a `MatchOrReturnExp` out of context and be invalid.
-In a nutshell, the matching rules for the `<-` operator should align closely
-with the usage known in list comprehensions.
 
 Motivation
 ==========
@@ -113,9 +108,9 @@ large number of programming languages. The language supports:
    - handled by `try ... [of ...] catch ... [after ...] end`
 2. links, `exit/2`, and `trap_exit`
 3. monitors
-4. return values such as `{ok, Val} | {error, Term}`, `{ok, Val} |
-   false`, or `ok | {error, Val}`
-5. A combination of one or more of the above
+4. return values such as `{ok, Val} | {error, Term}`,
+    `{ok, Val} | false`, or `ok | {error, Val}`
+5. a combination of one or more of the above
 
 So why should we look to add more? There are various reasons for this,
 including trying to reduce deeply nested conditional expressions,
@@ -159,10 +154,10 @@ By comparison, the same code could be written as follows with the new
 construct:
 
     commit_write(OpaqueData) ->
-        begin
-            ok <- disk_log:sync(OpaqueData#backup.file_desc),
-            ok <- disk_log:close(OpaqueData#backup.file_desc),
-            ok <- file:rename(OpaqueData#backup.tmp_file, OpaqueData#backup.file),
+        maybe
+            ok <~ disk_log:sync(OpaqueData#backup.file_desc),
+            ok <~ disk_log:close(OpaqueData#backup.file_desc),
+            ok <~ file:rename(OpaqueData#backup.tmp_file, OpaqueData#backup.file),
             {ok, OpaqueData#backup.file}
         end.
 
@@ -170,10 +165,10 @@ Or, to protect against `disk_log` calls returning something else than `ok |
 {error, Reason}`, the following form could be used:
 
     commit_write(OpaqueData) ->
-        begin
-            ok <- disk_log:sync(OpaqueData#backup.file_desc),
-            ok <- disk_log:close(OpaqueData#backup.file_desc),
-            ok <- file:rename(OpaqueData#backup.tmp_file, OpaqueData#backup.file),
+        maybe
+            ok <~ disk_log:sync(OpaqueData#backup.file_desc),
+            ok <~ disk_log:close(OpaqueData#backup.file_desc),
+            ok <~ file:rename(OpaqueData#backup.tmp_file, OpaqueData#backup.file),
             {ok, OpaqueData#backup.file}
         else
             {error, Reason} -> {error, Reason}
@@ -192,7 +187,7 @@ Both patterns have heavy weaknesses that makes them less than ideal.
 
 Folds over list of functions use patterns such as those defined in
 [posts from the
-mailing](http://erlang.org/pipermail/erlang-questions/2017-September/093575.html):
+mailing list](http://erlang.org/pipermail/erlang-questions/2017-September/093575.html):
 
     pre_check(Action, User, Context, ExternalThingy) ->
         Checks =
@@ -220,11 +215,11 @@ By comparison, the same code could be implemented with the new construct
 as:
 
     pre_check(Action, User, Context, ExternalThingy) ->
-        begin
-            ok <- check_request(Context, User),
-            ok <- check_permissions(Action, User),
-            ok <- check_dispatch_target(ExternalThingy),
-            ok <- check_condition(Action, Context),
+        maybe
+            ok <~ check_request(Context, User),
+            ok <~ check_permissions(Action, User),
+            ok <~ check_dispatch_target(ExternalThingy),
+            ok <~ check_condition(Action, Context),
             dispatch(Action, User, Context)
         end.
 
@@ -232,13 +227,13 @@ And if there was a need for derived state between any two steps, it
 would be easy to weave it in:
 
     pre_check(Action, User, Context, ExternalThingy) ->
-        begin
-            ok <- check_request(Context, User),
-            ok <- check_permissions(Action, User),
-            ok <- check_dispatch_target(ExternalThingy),
-            DispatchData <- dispatch_target(ExternalThingy),
-            ok <- check_condition(Action, Context),
-            dispatch(Action, User, Context)
+        maybe
+            ok <~ check_request(Context, User),
+            ok <~ check_permissions(Action, User),
+            ok <~ check_dispatch_target(ExternalThingy),
+            DispatchData <~ dispatch_target(ExternalThingy),
+            ok <~ check_condition(Action, Context),
+            dispatch(Action, User, Context, DispatchData)
         end.
 
 The list comprehension _hack_, by comparison, is a bit more rare. In
@@ -248,7 +243,7 @@ cases](https://github.com/erlang/otp/blob/869537a9bf799c8d12fc46c2b413e532d6e3b1
 or the [PropEr plugin for
 Rebar3](https://github.com/ferd/rebar3_proper/blob/e7eb96498a9d31f41c919474ec6800df62e237e1/src/rebar3_proper_prv.erl#L298-L308).
 
-Its overal form uses generators in list comprehensions to tunnel a happy
+Its overall form uses generators in list comprehensions to tunnel a happy
 path:
 
     [Res] =
@@ -262,10 +257,10 @@ This form doesn't see too much usage since it is fairly obtuse and I
 suspect most people have either been reasonable enough not to use it, or
 did not think about it. Obviously the new form would be cleaner:
 
-    begin
-        {ok, W} <- b(),
-        {ok, X} <- c(W),
-        {ok, Y} <- d(X),
+    maybe
+        {ok, W} <~ b(),
+        {ok, X} <~ c(W),
+        {ok, Y} <~ d(X),
         Z = e(Y),
         f(Z)
     end
@@ -339,11 +334,11 @@ construct:
         RelFile = filename:join(Dir, "RELEASES"),
         Backup = filename:join(Dir, "RELEASES.backup"),
         Change = filename:join(Dir, "RELEASES.change"),
-        begin
-            ok <- backup_releases(Dir, NewReleases, Masters, Backup, Change,
+        maybe
+            ok <~ backup_releases(Dir, NewReleases, Masters, Backup, Change,
                                   RelFile),
-            ok <- update_releases(Dir, NewReleases, Masters, Backup, Change),
-            ok <- move_releases(Dir, NewReleases, Masters, Backup, Change, RelFile)
+            ok <~ update_releases(Dir, NewReleases, Masters, Backup, Change),
+            ok <~ move_releases(Dir, NewReleases, Masters, Backup, Change, RelFile)
         end.
 
     backup_releases(Dir, NewReleases, Masters, Backup, Change, RelFile) ->
@@ -472,11 +467,10 @@ This section will detail the decision-making behind this EEP, including:
 - Prior Art in Other Languages
 - Whether to Normalize on Wrappers
 - Adding the `else` Block
-- The choice of `begin ... end` as a construct and its scope
-- Why reuse the arrow operator
+- The choice of `maybe ... end` as a construct and its scope
+- The choice of the matching operator `<~`
 - Other disregarded approaches
-- The choice of supported values
-- The choice of `{badunwrap, Val}` as a default exception
+- The choice of exceptions raised
 
 There's a lot of content to cover here.
 
@@ -770,7 +764,7 @@ and returns an `{:ok, term}` tuple, and the `~>` operator wraps a value
 into an `{:ok, term}` tuple.
 
 Whether to Normalize on Wrappers
----------------------
+--------------------------------
 
 In Erlang, `true` and `false` are regular atoms that only gained special
 status through usage in boolean expressions. It would be easy to think
@@ -803,8 +797,8 @@ would explicitly encourage this form of standardization.
 That being said, the variety of formats existing and the low amount of strict
 values being used would mean that forcing normalization calls for a potential
 loss of flexibility in future language decisions. For example,
-[EEP-54](https://github.com/erlang/eep/blob/master/eeps/eep-0054.md)—completed
-before final revisions of this RFC—tries to add new forms of context to error
+[EEP-54](https://github.com/erlang/eep/blob/master/eeps/eep-0054.md) —- completed
+before final revisions of this EEP -— tries to add new forms of context to error
 reports, and various libraries already rely on these richer patterns.
 
 It is therefore the opinion of the OTP technical board that we should **not**
@@ -820,8 +814,8 @@ Avoiding normalization on error and good values introduces the need for the
 
 Let's look with the following type of expression as an explanation why:
 
-    begin
-        {ok, {X,Y}} <- id({ok, {X,Y}})
+    maybe
+        {ok, {X,Y}} <~ id({ok, {X,Y}})
         ...
     end
 
@@ -843,9 +837,9 @@ To ask make it possible to alternatively get:
 Based on socket options set earlier. So let’s put it in context for the
 current proposal:
 
-    begin
-        {ok, {X,Y}} <- id({ok, {X,Y}}),
-        {ok, {PeerIP, PeerPort, Data}} <- gen_udp:recv(...),
+    maybe
+        {ok, {X,Y}} <~ id({ok, {X,Y}}),
+        {ok, {PeerIP, PeerPort, Data}} <~ gen_udp:recv(...),
         ...
     end
 
@@ -854,16 +848,16 @@ the socket is misconfigured to return `AncData`, would return `{ok, {PeerIP,
 PeerPort, AncData, Data}}` on a failure to match.
 
 Basically, an unexpected but good result could be returned from a
-function using the `begin ... end` construct, which would look like a
+function using the `maybe ... end` construct, which would look like a
 success while it was actually a complete failure to match and handle the
 information given. This is made even more ambiguous when data has the
 right shape and type, but a set of bound variables ultimately define
 whether the match succeeds or fails (in the case of a UDP socket,
 returning values that comes from the wrong peer, for example).
 
-In worst cases, It could let raw unformatted data exit a conditional
+In the worst cases, it could let raw unformatted data exit a conditional
 pipeline with no way to detect it after the fact, particularly if later
-functions in `begin ... end` apply transformations to text, such as
+functions in `maybe ... end` apply transformations to text, such as
 anonymizing or sanitizing data. This could be pretty unsafe
 and near impossible to debug well.
 
@@ -871,9 +865,9 @@ Think for example of:
 
     -spec fetch() -> {ok, iodata()} | {error, _}.
     fetch() ->
-        begin
-            {ok, B = <<_/binary>>} <- f(),
-            true <- validate(B),
+        maybe
+            {ok, B = <<_/binary>>} <~ f(),
+            true <~ validate(B),
             {ok, sanitize(B)}
         end.
 
@@ -892,9 +886,9 @@ reuses to clamp down on unexpected values:
 
     -spec fetch() -> {ok, iodata()} | {error, _}.
     fetch() ->
-        begin
-            {ok, B = <<_/binary>>} <- f(),
-            true <- validate(B),
+        maybe
+            {ok, B = <<_/binary>>} <~ f(),
+            true <~ validate(B),
             {ok, sanitize(B)}
         else
             false -> {error, invalid_data};
@@ -905,29 +899,31 @@ Here misconfigured sockets won’t result in unchecked data passing through
 your app; any invalid use case is captured, and if the value for `B` turns
 out to be a list, an `else_clause` error is raised with the bad value.
 
-Unless the clause is mandatory (it is not in Elixir and we do not plan it here
-either for compatibility reasons with existing `begin ... end` expressions),
-this level of additional matching is purely optional; the developer has no
-obvious incentive to go and handle these errors, and if they do, the exception
-raised will be through a missing clause in the `else` section, which will
-obscure its origin and line number.
+Unless the clause is mandatory (it is not in Elixir), this level of
+additional matching is purely optional; the developer has no obvious
+incentive to go and handle these errors, and if they do, the exception
+raised will be through a missing clause in the `else` section, which
+will obscure its origin and line number.
 
 We will therefore have to rely on education and documentation (along with
 type analysis) to prevent such issues from arising in the future.
 
-These problems would *not* exist with normalized error and return values as those used in statically-typed languages, but since we do not intend to normalize values, the `else` block is a necessary workaround.
+These problems would *not* exist with normalized error and return
+values as those used in statically-typed languages, but since we do
+not intend to normalize values, the `else` block is a necessary
+workaround.
 
-Choosing `begin ... end` Expressions
+Choosing `maybe ... end` Expressions
 ------------------------------------
 
 Abstractions over error flow requires to define a scope limiting the
-way flow is controlled. Before choosing the `begin ... end` expression,
+way flow is controlled. Before choosing the `maybe ... end` expression,
 the following items needed consideration:
 
 1. what is the scope we need to cover
 2. what is the format of the structure to use
-3. why ending up with `begin ... end`
-4. Why choose the `else` keyword
+3. why ending up with `maybe ... end`
+4. why choose the `else` keyword
 
 ### Scoping Limits
 
@@ -1083,7 +1079,7 @@ it should be of the form
 The questions remaining are: which keyword to choose, and which clauses
 to support.
 
-### Choosing `begin ... end`
+### Choosing `maybe ... end`
 
 Initially, a format similar to Elixir's `with` expression was being
 considered:
@@ -1134,6 +1130,11 @@ chosen was `maybe`, based on the Maybe monad. The problem is that
 introducing any new keyword carries severe risks to backwards
 compatibility.
 
+Since the OTP team is now planning to introduce a new mechanism for activation
+of new language features per module the potential risk for
+incompatibility with introducing a new keyword is reduced. Only
+modules explicitly using the new language feature will be impacted.
+
 For example, all of the following words were considered:
 
     ======= ================= =========================================
@@ -1168,16 +1169,6 @@ Initially, this proposal expected to use the `maybe` keyword:
 but for the reasons mentioned in the previous section, the `of ...`
 section became non-essential.
 
-Then, with the strong requirements for backwards compatibility making it
-difficult to introduce new keywords, along with the possibility to reuse
-`begin` without changing any of its current behavior, this form became the
-most interesting one.
-
-The term `begin` is also reminiscent of transactions and abortive
-contexts, which means that although not an ideal fit for value-based
-error flow, it is also not entirely outlandish and could accept the new
-added optional semantics without being too out of place.
-
 ### Why Choose the `else` keyword
 
 The first step here was looking at all the existing alternative reserved
@@ -1191,8 +1182,8 @@ in `if` expressions at a later date.
 A quick look at the OTP code base to be sure seems to return no `else()`
 function and should therefore be relatively safe to use in general.
 
-Reusing An Infix Operator
---------------------
+Choosing An Infix Operator
+--------------------------
 
 In order to form `MatchOrReturnExprs`, there is a need for a mechanism to
 introduce pattern matching with distinct semantics from regular pattern
@@ -1203,7 +1194,7 @@ most basic way to go:
 
     begin
         match_or_return(Pattern, Exp),
-        % variables bound in Pattern are available in scope
+        %% variables bound in Pattern are available in scope
         ...
     end
 
@@ -1212,24 +1203,32 @@ positions and make nesting really weird to deal with without exposing
 parse transform details and knowing how the code is translated.
 
 A prefix keyword such `let <Pattern> = <Exp>` could also be used.
-Such keywords unfortunately suffer the same issues as `maybe` would
-have, and `let` typically has different implications.
+However, that use of `let` would differ from how it is use in other
+languages and would be confusing.
 
 An infix operator seems like a good fit since pattern matching already
 uses them in multiple forms:
 
 - `=` is used for pattern matches. Overloading it in error flow would
   prevent regular matching from being used
+
 - `:=` is used for maps; using it could work, but would certainly be
   confusing when handling nested maps in a pattern
+
 - `<-` could make sense. It is already restricted in scope to list and
   binary comprehensions and would therefore not clash nor be confused.
   The existing semantics of the operator imply a literal
   pattern match working like a filter, which is what we are looking for.
+
 - `<=` same as `<-` but for binary generators
 
-The `<-` operator makes the most sense and shouldn't be confusing for
-anyone.
+- `<~` could make sense. It is a new operator that does not clash with
+  anything existing and it could be thought of as approximately
+  matching.
+
+The `<-` or the `<~` operators makes most sense. We choose `<~`,
+since `<-` in its current use means *sub set of* or *member of* which
+is not really what it is used for here.
 
 For completeness's sake, I also checked for alternative operators
 in a prior version of this EEP that introduced prescriptive values
@@ -1238,32 +1237,33 @@ for `{ok, T} | {error, R}`, which had distinct semantics:
     =======  ===========================================================
     Operator Description
     =======  ===========================================================
-    #=       no clash with other syntax (maps, records, integers), no
+    #=       No clash with other syntax (maps, records, integers), no
              clash with abstract patterns EEP either.
-    !=       No clash with message passing, but is sure to annone used
+    !=       No clash with message passing, but is sure to anyone used
              to C-style inequality checks
     <~       Works with no known conflict; shouldn't clash with ROK's
              frame proposals (uses infix ~ and < > as delimiters).
-    <|       reverse pipe operator. No obvious clash either
-
-The `<-` operator from list comprehensions is the most adequate
-option, both in terms of simplicity and cognitive costs.
+    <|       Reverse pipe operator. If Erlang were to implement Elixir's
+             pipe operator, it would probably make sense to implement both
+             `<|` and `|>` since the "interesting" argument often comes
+             last.
+    =~       Regular expression operator in Elixir and Perl.
 
 ### Operator Priority
 
 Within the expected usage of the unwrap expressions, the `<~` operator
 needs to have a precedence rule such that:
 
-    X = {Y,X} <- <Exp>
+    X = {Y,X} <~ <Exp>
 
 Is considered a valid pattern match operation with `X = {Y,X}` being the
 whole left-hand-side pattern, such that operation priorities are:
 
-    lhs <- rhs
+    lhs <~ rhs
 
 Instead of
 
-    lhs = rhs <- <...>
+    lhs = rhs <~ <...>
 
 In all other regards, the precedence rules should be the same as `=` in
 order to provide the most unsurprising experience possible.
@@ -1370,8 +1370,7 @@ Auto-wrapping return values is something the Elixir's `OK` library does,
 as well as Haskell's do notation, but that neither Rust nor Swift does.
 
 It seems that there is no very clear consensus on what could be done.
-Thus, for the simplicity of the implementation and backwards
-compatibility of the `begin ... end` expression, just returning the
+Thus, for the simplicity of the implementation, just returning the
 value as-is without auto-wrapping seems sensible, particularly
 since we do not prescribe tuple formats for handled values.
 
@@ -1399,38 +1398,30 @@ is chosen following Erlang/OTP standards:
 Since `case_clause` is functionally the closest exceptions and that it carries
 a value, we choose to replicate the same form here.
 
-The reason `else_clause` is chosen over `begin_clause` because the `else` block
+The reason `else_clause` is chosen over `maybe_clause` because the `else` block
 could arguably be used in other constructs in the future, and constraining the
 exception to the block's name itself is likely more future-proof.
 
 Backwards Compatibility
 =======================
 
-The possibility of an early exit from a `begin ... end` expression
-means that variables declared within its scope are now potentially
-unsafe to use outside of it.
+The new keyword `maybe` is introduced and might clash with existing
+use of unquoted `maybe` as an atom which in practice also includes use
+as a module or function name.
 
-This is a change of behaviour that brings `begin` in line with the
-variables bound within a `case ... end` branch, a `try/catch` clause, or
-a `receive ... end` branch. The same is true of the `else` block.
-
-This lack of safety only needs to be started at the first `MatchOrReturnExpr`
-encountered, since all variables bound before respect the same semantics as the
-existing `begin ... end` expression. If this analysis is done rather than just
-declaring all variables as unsafe wholesale, then there is no backwards
-compatibility concern to be had.
-
-The need for the `<-` operator to be used in a new context means code built
-with support for the new expressions won't be portable to older Erlang
-releases. However, if all the code is rewritten _after_ the AST and reuses
-existing core Erlang components, built BEAM artifacts should work on older
-versions fine. This is, however, not a supported use case by the OTP team.
+The plan is to introduce this new feature together with a mechanism
+that let the user activate it and other new features individually per
+module and by that the new keyword `maybe` will only be a potential
+incompatibility in the module where the user activates this feature.
 
 Reference Implementation
 ========================
 
-No reference implementation is usually required at this step.
-One is to be developed at a later point in time.
+There are two reference implementations:
+
+- [#5216: First proof of concept](https://github.com/erlang/otp/pull/5216)
+
+- [#5340: Implement the compiler part of EEP 49](https://github.com/erlang/otp/pull/5340)
 
 [EmacsVar]: <> "Local Variables:"
 [EmacsVar]: <> "mode: indented-text"


### PR DESCRIPTION
Introduce `maybe` as keyword to start the construct and `<~' as matching operator.
