### PR TITLE
EEP 64: Triple-Quoted Strings

### DIFF
--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -186,7 +186,7 @@ the string's content:
 Note that the following could be a syntax error; too short
 multi-line string since trailing newline shall be stripped
 both from the starting line and from the last content line,
-so the content could be seen as less then empty.
+so the content could be seen as less than empty.
 But it is more convenient to allow it as also an empty string:
 
     "" = """
@@ -285,8 +285,8 @@ would be syntax errors.
   syntax errors.  Only a few will have a subtly changed
   behaviour (string content).
 * Users can simply grep for `"""` in their source code.
-  Causing the same sequence e.g through macros would
-  be harder to find, but the worst problem would not
+  Creating the same sequence e.g through macros would
+  be harder to find; the worst problem would not
   be new syntax errors (hard to miss), but changed
   behaviour.  And the changed behaviour would be
   a slightly different string content.

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -155,12 +155,12 @@ value term.  It starts and ends with three double quotes: `"""`.
 Double quotes, `"`, are chosen because normal Erlang strings use them
 and this is just a new variant.  Since double quotes are used
 a triple-quoted string shall, as a normal string,
-produce a list of code-points.
+produce a list of characters (Unicode code-points).
 
 It would be more convenient if a triple-quoted string produced
 an UTF-8 binary, but that would be a surprising feature for double quotes,
 and the documentation build process can work around this by converting
-the code-point list (`string()`) into the needed binary chunk.
+the character list into the needed binary chunk.
 
 In source code a triple-quoted string is valid within a binary,
 so producing a Unicode binary is reasonably straightforward:
@@ -176,7 +176,7 @@ multi-line strings here.
 As a future expansion it has been proposed to use [Sigils][] (prefixes)
 for specialized strings such as regular expressions,
 interpolated variables ([PR-7343][]), Unicode binary strings, etc.
-For example: `X = ~u"Tschüß"` for an UTF-8 encoded string.
+For example: `X = ~u"Tschüß"` for an UTF-8 encoded binary.
 
 ### Triple-Quoted String Start
 

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -6,7 +6,7 @@
     Erlang-Version: OTP-27
     Post-History:
 ****
-EEP 64: Multi-line Indented Verabatim Strings
+EEP 64: Multi-line Indented Verbatim Strings
 ----
 
 Abstract
@@ -101,7 +101,7 @@ the documentation build process can convert the codepoint list
 into the needed binary chunk.
 
 In source code a MIV String is valid in a binary so
-producing a unicode binary is reasonably straightforward:
+producing a Unicode binary is reasonably straightforward:
 
     X = <<"""
         Line 1
@@ -113,12 +113,12 @@ multi-line strings here.
 
 As a future expansion it has been proposed to use prefixes
 for specialized strings such as regular expressions,
-interpolated variables ([PR-7343][]), unicode binary strings, etc.
+interpolated variables ([PR-7343][]), Unicode binary strings, etc.
 For example: `X = u"Tschüß"` for an UTF-8 encoded string.
 
 ### MIV String Start
 
-After the starting `"""` only whitespace is allowed
+After the starting `"""` only white-space is allowed
 up to the end of the line.
 
 As a possible future expansion we might allow a keyword here
@@ -138,7 +138,7 @@ A later step, preferably done by the parser, strips the
 characters up to and including the newline from the
 first line of the string.
 
-If any of these characters is not whitespace,
+If any of these characters is not white-space,
 the parser reports a syntax error.
 
 ### MIV String End
@@ -146,21 +146,21 @@ the parser reports a syntax error.
 All bytes are collected as they are (verbatim) and becomes
 the MIV String content.
 
-A MIV String ends with whitespace on a new line followed by `"""`.
+A MIV String ends with white-space on a new line followed by `"""`.
 This completes the scanner token.
 
-A later step, preferably done by the parser, uses the whitespace
+A later step, preferably done by the parser, uses the white-space
 on the ending line as the definition of the string's indentation
-and strips that whitespace seqence from every line in the string,
+and strips that white-space sequence from every line in the string,
 and strips the newline preceding the ending line.
 
 If any of the lines should not start with the defined indentation
 either because the line is too short or if the prefix differs,
 the parser reports a syntax error.
 
-Requiring that all lines must have exactly the same whitspace
+Requiring that all lines must have exactly the same white-space
 characters as indentation is a simple solution to not have
-to define how indentation whitespace (tab vs. space) normalization
+to define how indentation white-space (tab vs. space) normalization
 should be done, and also seems like a reasonable requirement.
 
 ### Leading and trailing newline
@@ -182,13 +182,13 @@ the string's content:
     "" = """
          """
 
-The definition of newline and whitespace is the same as
+The definition of newline and white-space is the same as
 the current in the scanner, but; when stripping the newline
 from the line preceding the ending line, a CR should also
 be stripped, if the line ends in CR LF.
 
 This is a convenience for systems where CR LF is used as newline.
-In most places in the scanner CR is treated as whitespace,
+In most places in the scanner CR is treated as white-space,
 but in this case it would be inconvenient to not strip the CR.
 
 ### Indentation
@@ -218,7 +218,7 @@ determines the indentation.
         """,
 
     """ This is a syntax error
-    (non-whitespace on start line)
+    (non-white-space on start line)
     """,
 
     """
@@ -262,7 +262,7 @@ Also, this is valid today:
 
 But according to this EEP it would be two syntax errors:
 
-1. The start line has got non-whitespace after `"""`.
+1. The start line has got non-white-space after `"""`.
 2. The first content line has incorrect indentation.
 
 There are many other similar constructions that also
@@ -281,7 +281,7 @@ would be syntax errors.
   behaviour.  And the changed behaviour would be
   a slightly different string content.
 
-Therefore, it should be very unlikly that anyone
+Therefore, it should be very unlikely that anyone
 encounters a real backwards incompatibility problem
 from the suggestions in this EEP.
 

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -170,8 +170,8 @@ so producing a Unicode binary is reasonably straightforward:
         Line 2
         """/utf8>>
 
-The 2 + 7 characters overhead is not exhausting since we are targeting
-multi-line strings here.
+The 2 + 7 characters ("`<<`" + "`/utf8>>`") overhead is not exhausting
+since we are targeting multi-line strings here.
 
 As a future expansion it has been proposed to use [Sigils][] (prefixes)
 for specialized strings such as regular expressions,

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -197,11 +197,11 @@ The scanner does not need to have any special treatment
 for the string content on the line after the starting
 `"""` except that it should not search for an ending `"""`.
 
-A later step, preferably done by the parser, strips the
-characters up to and including the newline from the string content.
+A later step strips the characters up to and including the newline
+from the string content.
 
 If any of these characters is not white-space,
-the parser reports a syntax error.
+   a syntax error is reported.
 
 ### Triple-Quoted String End
 
@@ -211,14 +211,14 @@ the string content.
 A triple-quoted string ends with newline followed by optional white-space
 and then `"""`.  This completes the scanner token.
 
-A later step, preferably done by the parser, uses the white-space
-on the ending line as the definition of the string's indentation
+A later step uses the white-space on the ending line
+as the definition of the string's indentation
 and strips that particular white-space sequence from every line
 in the string, and strips the newline preceding the ending line.
 
 If any of the lines do not start with the defined indentation
 either because the line is too short or if the prefix differs,
-the parser reports a syntax error.
+a syntax error is reported.
 
 Requiring that all lines must have exactly the same indentation
 characters is a simple solution to not have to define how indentation

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -1,175 +1,342 @@
-    Author: Kiko Fernandez-Reyes <kiko(at)erlang(dot)org>
+    Author: Kiko Fernandez-Reyes <kiko(at)erlang(dot)org>,
+        Raimo Niskanen <raimo(at)erlang(dot)org>
     Status: Draft
     Type: Standards Track
     Created: 07-Jun-2023
     Erlang-Version: OTP-27
     Post-History:
 ****
-EEP XXX: Triple-quoted binary strings
+EEP 64: Multi-line Indented Verabatim Strings
 ----
 
 Abstract
 ========
 
-This EEP proposes the introduction of triple-quoted binary-strings syntax and
-runtime semantics. The main benefit is to allow multi-line binary strings in an
-easy way, similar to other languages, e.g., Elixir.
+This EEP proposes the introduction of Multi-line Indented Verbatim strings,
+*MIV Strings* and defines their semantics.  The main benefit is to allow
+*multi-line* strings in an easy and useful, *indented*, way,
+similar to in other languages, e.g Elixir.
+
+Their first use case is for in-module documentation attributes
+containing [Markdown][] or similarly formatted text where *verbatim* text
+is desirable since any documentation text format has its own notion
+of escape sequences which will collide with Erlang's escape sequences.
 
 Rationale
 =========
 
-One limitation of Erlang today (June 2023) is the ability to write multi-line
-string binaries. That said, the main reason to consider this EEP is
-[EEP-59][] where documentation attributes can
-benefit from multi-line string binaries: the documentation generates Docs chunks
-format -- documentation in its binary format-- which saves space and makes the
-documentation available to the shell.
+Today (June 2023), writing multi-line strings is awkward and arguably ugly.
+They may contain escape sequences and have no concept of indentation:
 
-Triple-Quoted Binary-String Design Decisions
----------------------------------------------
+    foo () ->
+        case bar() of
+             ok ->
+                 X = "First line
+    Second line with \"\\*not emphasized\\* Markdown\"
+    Third line",
+                 {ok, X}
+        end.
 
-### Runtime semantics
+The content's indentation cannot adhere to the surrounding code's
+and the `*` has to be doubly escaped to get a  `\*` character
+sequence into the actual content.
 
-Triple-quoted strings should only produce binary-strings. This makes easy to
-avoid typing issues with union types, and makes clear that a triple-quoted string
-does not need function with guards to test if the produce result is a list or a
-binary (this can happen if Erlang adds string interpolation,
-[EEP-62][],
-[PR-7343][]).
+In a documentation attribute as suggested in [EEP 59][]
+the indentation problem is not that pronounced because
+the documentation attribute itself is not much indented:
 
-Triple-quoted binary-strings do not allow string interpolation and, if we were
-to accept them, only calls to statically known values should be allowed, e.g.,
-macros. This design decision forbids the creation of dynamic documentation that
-generates code at runtime, e.g., doing an IO call to get a value not known
-statically and based on it perform an action (notice that this is allowed when
-using string interpolation).
+    -doc """
+        First line
+        Second line with "\*not emphasized\* Markdown"
+        Third line
+        """.
 
-### Binary-String Design
+The main reason to consider this EEP is for documentation
+attributes, and here not having to worry about escape sequences
+is the most attractive property of this EEP.  But introducing
+a new string format will also require defining how it would behave
+in Erlang code.
 
-To make the usage of binary-string similar to other languages, this EEP proposal
-makes the binary-string design decisions similar to the ones for the Elixir language.
+Having a string format only allowed in attributes would simply be
+very strange and the one suggested in this EEP would be useful
+also in Erlang code.
 
-#### Binary-String Start and End
+Design Decisions
+----------------
 
-Binary-strings must start and end with triple-quotes in their own lines:
+An attribute is an Erlang form in the source code
+that consists of a `-` token, an atom, one value term and a full stop
+(dot).  The value term may be enclosed in parentheses
+(which is not very interesting for documentation attributes).
 
-*Code Example*
+    -doc "  Badly formatted
+    documentation paragraph
+    /-\\
+    \\-/".
+
+A documentation attribute should have a string as its content term,
+and here we want to use our new and more convenient MIV String
+instead of a normal string:
+
+    -doc """
+          Better formatted
+        documentation paragraph
+        /-\
+        \-/
+        """.
+
+### MIV String Scanner Token
+
+A MIV String must be a token that the scanner recognizes as a string,
+which makes it suitable for a documentation attribute value term.
+It starts and ends with three double quotes: `"""`.
+
+Double quotes, `"`, are chosen because normal Erlang strings use them
+and this is just a new variant.  Since double quotes are used
+a MIV String should, as a normal string, produce a list of codepoints.
+
+It would be more convenient if a MIV String produced an UTF-8 binary,
+but that would be surprising when using double quotes, and
+the documentation build process can convert the codepoint list
+into the needed binary chunk.
+
+In source code a MIV String is valid in a binary so
+producing a unicode binary is reasonably straightforward:
+
+    X = <<"""
+        Line 1
+        Line 2
+        """/utf8>>
+
+The extra overhead is not exhausting since this we are targeting
+multi-line strings here.
+
+As a future expansion it has been proposed to use prefixes
+for specialized strings such as regular expressions,
+interpolated variables ([PR-7343][]), unicode binary strings, etc.
+For example: `X = u"Tschüß"` for an UTF-8 encoded string.
+
+### MIV String Start
+
+After the starting `"""` only whitespace is allowed
+up to the end of the line.
+
+As a possible future expansion we might allow a keyword here
+that shouldn't be part of the string content, but could be
+a hint for for syntax highlighting in the editor.
+
+    -doc """ md
+        Markdown content
+        * Bullet list
+        """.
+
+The scanner does not need to have any special treatment
+for the string content on the line after the starting
+`"""` except that it should not search for an ending `"""`.
+
+A later step, preferably done by the parser, strips the
+characters up to and including the newline from the
+first line of the string.
+
+If any of these characters is not whitespace,
+the parser reports a syntax error.
+
+### MIV String End
+
+All bytes are collected as they are (verbatim) and becomes
+the MIV String content.
+
+A MIV String ends with whitespace on a new line followed by `"""`.
+This completes the scanner token.
+
+A later step, preferably done by the parser, uses the whitespace
+on the ending line as the definition of the string's indentation
+and strips that whitespace seqence from every line in the string,
+and strips the newline preceding the ending line.
+
+If any of the lines should not start with the defined indentation
+either because the line is too short or if the prefix differs,
+the parser reports a syntax error.
+
+Requiring that all lines must have exactly the same whitspace
+characters as indentation is a simple solution to not have
+to define how indentation whitespace (tab vs. space) normalization
+should be done, and also seems like a reasonable requirement.
+
+### Leading and trailing newline
+
+The rules above strips one leading and one trailing newline.
+This is a simple convention that also gives control over
+the string's content:
+
+    "\n  X\n" = """
+        
+          X
+        
+        """,
+    
+    "X" = """
+        X
+        """,
+    
+    "" = """
+         """
+
+The definition of newline and whitespace is the same as
+the current in the scanner, but; when stripping the newline
+from the line preceding the ending line, a CR should also
+be stripped, if the line ends in CR LF.
+
+This is a convenience for systems where CR LF is used as newline.
+In most places in the scanner CR is treated as whitespace,
+but in this case it would be inconvenient to not strip the CR.
+
+### Indentation
+
+The rules above facilitates indentation of the content
+to adhere to the surrounding code.  The ending line
+determines the indentation.
+
+    "This text\nhas no indentation" = """
+        This text
+        has no indentation
+        """,
+    
+    "    This text\n    has indentation" = """
+            This text
+            has indentation
+        """,
+    
+    "  This text\nhas an indented first line" =
+        """
+          This text
+        has an indented first line
+        """,
+    
+    """
+    This is a syntax error (incorrect indentation)
+        """,
+
+    """ This is a syntax error
+    (non-whitespace on start line)
+    """,
+
+    """
+    This will probably be a syntax error
+    since no ending line can be found"""
+
+### Backwards incompatibility
+
+This is valid today:
 
     X = """
-        This is the beginning of the triple-quote text
+        X
         """
 
-*Documentation Example*
+It is equivalent to:
+
+    X = "" "
+        X
+        " ""
+
+Which is equivalent to:
+
+    X = "
+        X
+        "
+
+Which is equivalent to:
+
+    X = "\n    X\n"
+
+But with the suggested MIV Strings the first
+code snippet would instead be equivalent to:
+
+    X = "X"
+
+Also, this is valid today:
+
+    X = """ xxx
+      X
+        """
+
+But according to this EEP it would be two syntax errors:
+
+1. The start line has got non-whitespace after `"""`.
+2. The first content line has incorrect indentation.
+
+There are many other similar constructions that also
+would be syntax errors.
+
+* It is far from likely that anyone has deliberately
+  used `"""` in source code to mean an empty string
+  concatenated to another string.
+* Most today allowed combinations with `"""` will cause
+  syntax errors.  Only a few will have a subtly changed
+  behaviour (string content).
+* Users can simply grep for `"""` in their source code.
+  Causing the same sequence e.g through macros would
+  be harder to find, but the worst problem would not
+  be new syntax errors (hard to miss), but changed
+  behaviour.  And the changed behaviour would be
+  a slightly different string content.
+
+Therefore, it should be very unlikly that anyone
+encounters a real backwards incompatibility problem
+from the suggestions in this EEP.
+
+### Quoting of `"""`
+
+In the rules above there is no possibility to have `"""`
+first on a line in a MIV String.
+
+This would be allowed:
 
     -doc """
-         Removes double-quotes (") from a given string
-         """
-    remove_double_quotes(X) -> 
+        A MIV String starts with: """
+        and ends with: """
+        """.
 
-#### Binary-Strings Closing of Triple-Quotes
+As long as `"""` isn't first on a line.
 
-The closing of the triple-quotes denotes the space (indentation):
+It would be possible to work around in Erlang code:
 
-*1. Code Example*
+    X = """
+        A MIV String starts with:
+        ""
+        """ """
+        "
+        and ends with:
+        ""
+        """ "\""
 
-    >> X = """
-           This text
-           has no indentation
-           """
-    
-    Equivalent to: <<"This text\nhas no indentation\n">>
+That is ugly, and it is not possible in a documentation
+attribute where string concatenation isn't allowed.
 
-*2. Code Example*
+We can either ignore the problem since it is only
+when placed first on a line that `"""` is a problem,
+or we can use the GitHub [Markdown][] trick to allow
+3 or more start characters and matching end characters
+so this would be valid:
 
-    >> Y = """
-           This text
-           has indentation
-    """
-    
-    Equivalent to: <<"       This text\n       has indentation\n">>
-
-*3. Code Example*
-
-    >> Z = """
-      This text has
-      two space indentation
-    """
-    
-    Equivalent to: <<"  This text has\n  two space indentation\n">>
-
-*1. Documentation Example - No indentation*
-
-    -doc """
-         Removes double-quotes (") from a given string
-         """
-    remove_double_quotes(X) -> 
-
-*2. Documentation Example - No indentation*
-
-    -doc """
-    Removes double-quotes (") from a given string
-    """
-    remove_double_quotes(X) -> 
-
-*3. Documentation Example - Indentation*
-
-    -doc """
-         Removes double-quotes (") from a given string
-    """
-    remove_double_quotes(X) -> 
-
-#### Binary-Strings Errors
-
-An error should be raised when there is text that starts before the closing of triple-quotes, where
-the error makes the code written using triple-quotes to have a uniform style:
-
-*Code Example*
-
-    >> Err = """
-    This shall be an error
-             """
-   
-    error             
-
-*Documentation Example*
-
-    -doc """
-    Removes double-quotes (") from a given string
-         """
-    remove_double_quotes(X) -> 
-
-#### Escaping Newlines in Triple-Quotes
-
-Escaping new lines using `\`:
-
-To write `\` inside triple quotes, one needs to use `\\`. [EEP-59][] should
-ignore the meaning of `\` if inside a code block.
-
-*Code Example*
-
-    >> X = """
-           This text \
-           has no indentation
-           """
-    
-    Equivalent to: <<"This text has no indentation\n">>
-
-*Documentation Example*
-
-    -doc """
-    Removes double-quotes (") \
-    from a given string
-    """
-    remove_double_quotes(X) -> 
+    X = """"
+        A MIV String starts with:
+        """
+        and ends with:
+        """
+        """"
 
 [EEP 59]: https://www.erlang.org/eeps/eep-0059
     "EEP 59: Module attributes for documentation"
 
-[EEP-62]: https://www.erlang.org/eeps/eep-0062
+[EEP 62]: https://www.erlang.org/eeps/eep-0062
     "String Interpolation Syntax"
 
 [PR-7343]: https://github.com/erlang/otp/pull/7343
     "Feature: String Interpolation"
+
+[Markdown]: https://github.github.com/gfm/
+    "GitHub Flavored Markdown"
 
 Copyright
 =========

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -1,0 +1,187 @@
+    Author: Kiko Fernandez-Reyes <kiko(at)erlang(dot)org>
+    Status: Draft
+    Type: Standards Track
+    Created: 07-Jun-2023
+    Erlang-Version: OTP-27
+    Post-History:
+****
+EEP XXX: Triple-quoted binary strings
+----
+
+Abstract
+========
+
+This EEP proposes the introduction of triple-quoted binary-strings syntax and
+runtime semantics. The main benefit is to allow multi-line binary strings in an
+easy way, similar to other languages, e.g., Elixir.
+
+Rationale
+=========
+
+One limitation of Erlang today (June 2023) is the ability to write multi-line
+string binaries. That said, the main reason to consider this EEP is
+[EEP-59][] where documentation attributes can
+benefit from multi-line string binaries: the documentation generates Docs chunks
+format -- documentation in its binary format-- which saves space and makes the
+documentation available to the shell.
+
+Triple-Quoted Binary-String Design Decisions
+---------------------------------------------
+
+### Runtime semantics
+
+Triple-quoted strings should only produce binary-strings. This makes easy to
+avoid typing issues with union types, and makes clear that a triple-quoted string
+does not need function with guards to test if the produce result is a list or a
+binary (this can happen if Erlang adds string interpolation,
+[EEP-62][],
+[PR-7343][]).
+
+Triple-quoted binary-strings do not allow string interpolation and, if we were
+to accept them, only calls to statically known values should be allowed, e.g.,
+macros. This design decision forbids the creation of dynamic documentation that
+generates code at runtime, e.g., doing an IO call to get a value not known
+statically and based on it perform an action (notice that this is allowed when
+using string interpolation).
+
+### Binary-String Design
+
+To make the usage of binary-string similar to other languages, this EEP proposal
+makes the binary-string design decisions similar to the ones for the Elixir language.
+
+#### Binary-String Start and End
+
+Binary-strings must start and end with triple-quotes in their own lines:
+
+*Code Example*
+
+    X = """
+        This is the beginning of the triple-quote text
+        """
+
+*Documentation Example*
+
+    -doc """
+         Removes double-quotes (") from a given string
+         """
+    remove_double_quotes(X) -> 
+
+#### Binary-Strings Closing of Triple-Quotes
+
+The closing of the triple-quotes denotes the space (indentation):
+
+*1. Code Example*
+
+    >> X = """
+           This text
+           has no indentation
+           """
+    
+    Equivalent to: <<"This text\nhas no indentation\n">>
+
+*2. Code Example*
+
+    >> Y = """
+           This text
+           has indentation
+    """
+    
+    Equivalent to: <<"       This text\n       has indentation\n">>
+
+*3. Code Example*
+
+    >> Z = """
+      This text has
+      two space indentation
+    """
+    
+    Equivalent to: <<"  This text has\n  two space indentation\n">>
+
+*1. Documentation Example - No indentation*
+
+    -doc """
+         Removes double-quotes (") from a given string
+         """
+    remove_double_quotes(X) -> 
+
+*2. Documentation Example - No indentation*
+
+    -doc """
+    Removes double-quotes (") from a given string
+    """
+    remove_double_quotes(X) -> 
+
+*3. Documentation Example - Indentation*
+
+    -doc """
+         Removes double-quotes (") from a given string
+    """
+    remove_double_quotes(X) -> 
+
+#### Binary-Strings Errors
+
+An error should be raised when there is text that starts before the closing of triple-quotes, where
+the error makes the code written using triple-quotes to have a uniform style:
+
+*Code Example*
+
+    >> Err = """
+    This shall be an error
+             """
+   
+    error             
+
+*Documentation Example*
+
+    -doc """
+    Removes double-quotes (") from a given string
+         """
+    remove_double_quotes(X) -> 
+
+#### Escaping Newlines in Triple-Quotes
+
+Escaping new lines using `\`:
+
+To write `\` inside triple quotes, one needs to use `\\`. [EEP-59][] should
+ignore the meaning of `\` if inside a code block.
+
+*Code Example*
+
+    >> X = """
+           This text \
+           has no indentation
+           """
+    
+    Equivalent to: <<"This text has no indentation\n">>
+
+*Documentation Example*
+
+    -doc """
+    Removes double-quotes (") \
+    from a given string
+    """
+    remove_double_quotes(X) -> 
+
+[EEP 59]: https://www.erlang.org/eeps/eep-0059
+    "EEP 59: Module attributes for documentation"
+
+[EEP-62]: https://www.erlang.org/eeps/eep-0062
+    "String Interpolation Syntax"
+
+[PR-7343]: https://github.com/erlang/otp/pull/7343
+    "Feature: String Interpolation"
+
+Copyright
+=========
+
+This document is placed in the public domain or under the CC0-1.0-Universal
+license, whichever is more permissive.
+
+[EmacsVar]: <> "Local Variables:"
+[EmacsVar]: <> "mode: indented-text"
+[EmacsVar]: <> "indent-tabs-mode: nil"
+[EmacsVar]: <> "sentence-end-double-space: t"
+[EmacsVar]: <> "fill-column: 70"
+[EmacsVar]: <> "coding: utf-8"
+[EmacsVar]: <> "End:"
+[VimVar]: <> " vim: set fileencoding=utf-8 expandtab shiftwidth=4 softtabstop=4: "

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -6,16 +6,16 @@
     Erlang-Version: OTP-27
     Post-History:
 ****
-EEP 64: Multi-line Indented Verbatim Strings
+EEP 64: Verbatim Multi-line Indented Strings
 ----
 
 Abstract
 ========
 
-This EEP proposes the introduction of Multi-line Indented Verbatim strings,
-*MIV Strings* and defines their semantics.  The main benefit is to allow
-*multi-line* strings in an easy and useful, *indented*, way,
-similar to in other languages, e.g Elixir.
+This EEP proposes the introduction of Verbatim Multi-line Indented strings,
+*VMI Strings*, and defines their semantics.  The main benefit is to allow
+*multi-line* strings in an easy and useful (*indented*) way,
+similar to other languages, e.g. Elixir.
 
 Their first use case is for in-module documentation attributes
 containing [Markdown][] or similarly formatted text where *verbatim* text
@@ -41,7 +41,7 @@ The content's indentation cannot adhere to the surrounding code's
 and the `*` has to be doubly escaped to get a  `\*` character
 sequence into the actual content.
 
-In a documentation attribute as suggested in [EEP 59][]
+In a documentation attribute as suggested in [EEP 59][],
 the indentation problem is not that pronounced because
 the documentation attribute itself is not much indented:
 
@@ -52,14 +52,14 @@ the documentation attribute itself is not much indented:
         """.
 
 The main reason to consider this EEP is for documentation
-attributes, and here not having to worry about escape sequences
-is the most attractive property of this EEP.  But introducing
-a new string format will also require defining how it would behave
+attributes, where not having to worry about escape sequences
+is this EEP's most attractive property.  Introducing a new string
+format, however, will also require defining how it shall behave
 in Erlang code.
 
-Having a string format only allowed in attributes would simply be
-very strange and the one suggested in this EEP would be useful
-also in Erlang code.
+Having a string format that is only allowed in attributes would
+simply be very strange and the one suggested in this EEP
+would also be useful in Erlang code.
 
 Design Decisions
 ----------------
@@ -75,7 +75,7 @@ that consists of a `-` token, an atom, one value term and a full stop
     \\-/".
 
 A documentation attribute should have a string as its content term,
-and here we want to use our new and more convenient MIV String
+and here we want to use our new and more convenient VMI String
 instead of a normal string:
 
     -doc """
@@ -85,23 +85,23 @@ instead of a normal string:
         \-/
         """.
 
-### MIV String Scanner Token
+### VMI String Scanner Token
 
-A MIV String must be a token that the scanner recognizes as a string,
+A VMI String must be a token that the scanner recognizes as a string,
 which makes it suitable for a documentation attribute value term.
 It starts and ends with three double quotes: `"""`.
 
 Double quotes, `"`, are chosen because normal Erlang strings use them
 and this is just a new variant.  Since double quotes are used
-a MIV String should, as a normal string, produce a list of codepoints.
+a VMI String shall, as a normal string, produce a list of codepoints.
 
-It would be more convenient if a MIV String produced an UTF-8 binary,
-but that would be surprising when using double quotes, and
-the documentation build process can convert the codepoint list
-into the needed binary chunk.
+It would be more convenient if a VMI String produced an UTF-8 binary,
+but that would be a surprising feature for double quotes, and
+the documentation build process can work around this by converting
+the codepoint list (`string()`) into the needed binary chunk.
 
-In source code a MIV String is valid in a binary so
-producing a Unicode binary is reasonably straightforward:
+In source code a VMI String is valid in a binary,
+so producing a Unicode binary is reasonably straightforward:
 
     X = <<"""
         Line 1
@@ -116,7 +116,7 @@ for specialized strings such as regular expressions,
 interpolated variables ([PR-7343][]), Unicode binary strings, etc.
 For example: `X = u"Tschüß"` for an UTF-8 encoded string.
 
-### MIV String Start
+### VMI String Start
 
 After the starting `"""` only white-space is allowed
 up to the end of the line.
@@ -141,20 +141,20 @@ first line of the string.
 If any of these characters is not white-space,
 the parser reports a syntax error.
 
-### MIV String End
+### VMI String End
 
 All bytes are collected as they are (verbatim) and becomes
-the MIV String content.
+the VMI String content.
 
-A MIV String ends with white-space on a new line followed by `"""`.
-This completes the scanner token.
+A VMI String ends with newline followed by optional white-space
+and then by  `"""`.  This completes the scanner token.
 
 A later step, preferably done by the parser, uses the white-space
 on the ending line as the definition of the string's indentation
 and strips that white-space sequence from every line in the string,
 and strips the newline preceding the ending line.
 
-If any of the lines should not start with the defined indentation
+If any of the lines do not start with the defined indentation
 either because the line is too short or if the prefix differs,
 the parser reports a syntax error.
 
@@ -179,6 +179,16 @@ the string's content:
         X
         """,
     
+    "" = """
+         
+         """
+
+Note that the following could be a syntax error; too short
+multi-line string since trailing newline shall be stripped
+both from the starting line and from the last content line,
+so the content could be seen as less then empty.
+But it is more convenient to allow it as also an empty string:
+
     "" = """
          """
 
@@ -249,7 +259,7 @@ Which is equivalent to:
 
     X = "\n    X\n"
 
-But with the suggested MIV Strings the first
+But with the suggested VMI Strings the first
 code snippet would instead be equivalent to:
 
     X = "X"
@@ -288,12 +298,12 @@ from the suggestions in this EEP.
 ### Quoting of `"""`
 
 In the rules above there is no possibility to have `"""`
-first on a line in a MIV String.
+first on a line in a VMI String.
 
 This would be allowed:
 
     -doc """
-        A MIV String starts with: """
+        A VMI String starts with: """
         and ends with: """
         """.
 
@@ -302,7 +312,7 @@ As long as `"""` isn't first on a line.
 It would be possible to work around in Erlang code:
 
     X = """
-        A MIV String starts with:
+        A VMI String starts with:
         ""
         """ """
         "
@@ -320,7 +330,7 @@ or we can use the GitHub [Markdown][] trick to allow
 so this would be valid:
 
     X = """"
-        A MIV String starts with:
+        A VMI String starts with:
         """
         and ends with:
         """

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -15,7 +15,7 @@ Abstract
 This EEP proposes the introduction of *Triple-Quoted Strings*,
 and defines their semantics.  The main benefit is to allow
 multi-line strings in an easy and useful way,
-i.e. with indentation, similar to other languages, e.g. Elixir.
+i.e. with indentation, similar to other languages, e.g. [Elixir][].
 
 Their first use case is for in-module documentation attributes
 containing [Markdown][] or similarly formatted text where verbatim text
@@ -93,6 +93,59 @@ instead of a normal string:
         \-/
         """.
 
+### Verbatim Strings
+
+We want the strings to be verbatim since then they are sure
+to not clash with any documentation text format.  In [Markdown][]
+(and [AsciiDoc][]) it is the use of the backslash character (`\`)
+that collides since it has a meaning in normal Erlang strings,
+so every backslash would need to be escaped into double backslash
+if the string accepts escape sequences.
+
+This is in many cases not a big problem, though.  [Elixir][] also uses
+[Markdown][] as documentation format and mostly ignores this problem.
+But in some modules, it *is* a problem, such as the regular expression
+module, and there [Sigils][] for verbatim text are used to avoid
+quoting all backslashes.
+
+We could also do like Elixir and choose both, but then we have
+to implement [Sigils][] or something like that before getting
+triple-quoted strings that are useful enough.
+
+So if we have to choose one format, it should be the Verbatim one,
+since that is the more general format, also in code;
+where you simply would want to define a string for some purpose,
+impossible to foresee.
+
+This does not close the door on [Sigils][].  We can state that
+we have merely chosen that the default for triple-quoted strings
+is verbatim, and for normal strings it is escaped.  Although
+it is a bit annoying that we then do not have the same defaults
+as [Elixir][], there are other more annoying subtle differences
+between strings in the languages.  See [Comparison with Elixir][].
+
+Because the strings are verbatim, and we want to use them
+to define any string in code, we cannot have the limitation
+that there always is a newline at the end.  Therefore the
+last newline (the newline on the line that precedes
+the string ending line) should be stripped.  It is easy
+to add a newline if an ending newline is needed.
+
+[Elixir][] does not strip the last newline and dodges this problem
+by escaping newlines.  If you do not want the last newline you put
+a backslash last on the last line.  This does not work in their
+verbatim strings, though.  So you have to choose between either
+verbatim with ending newline or having to escape backslashes.
+
+A slightly annoying consequence of verbatim strings with a fixed
+end marker there is no possibility to create a string containing
+such an end marker.  Therefore this EEP, as a possible extension,
+suggests allowing not only triple-quoted strings,
+but 3-or-more-quoted strings.  Then a start and end marker
+can be chosen that is not part of the string,
+and any string can be created.  This is a not so pretty solution
+for a very rare corner case.
+
 ### Triple-Quoted String Scanner Token
 
 A triple-quoted string must be a token that the scanner recognizes
@@ -117,10 +170,10 @@ so producing a Unicode binary is reasonably straightforward:
         Line 2
         """/utf8>>
 
-The extra overhead is not exhausting since this we are targeting
+The 2 + 7 characters overhead is not exhausting since we are targeting
 multi-line strings here.
 
-As a future expansion it has been proposed to use sigils (prefixes)
+As a future expansion it has been proposed to use [Sigils][] (prefixes)
 for specialized strings such as regular expressions,
 interpolated variables ([PR-7343][]), Unicode binary strings, etc.
 For example: `X = ~u"Tschüß"` for an UTF-8 encoded string.
@@ -130,7 +183,7 @@ For example: `X = ~u"Tschüß"` for an UTF-8 encoded string.
 After the starting `"""` only white-space is allowed
 up to the end of the line.
 
-As a possible future expansion we might allow a keyword here
+As a possible future expansion we might allow text here
 that shouldn't be part of the string content, but could be
 a hint for e.g. syntax highlighting and indentation handling
 in an editor / pretty printer.
@@ -152,7 +205,7 @@ the parser reports a syntax error.
 
 ### Triple-Quoted String End
 
-All bytes are collected as they are (verbatim) and becomes
+All characters are collected as they are (verbatim) and becomes
 the string content.
 
 A triple-quoted string ends with newline followed by optional white-space
@@ -178,9 +231,9 @@ The characters `CR` - Unicode code-point value 13,
 `LF` - code-point 10, and white-space - as as defined
 in the Erlang scanner today, are handled as usual by the scanner,
 except that if the line preceding the ending line
-ends in `CR` `LF` then also the `CR` is interpreted
+ends in `CR LF` then also the `CR` is interpreted
 as part of the newline and is stripped along with the `LF`.
-This is a convenience for systems with `CR` `LF` newlines.
+This is a convenience for systems with `CR LF` newlines.
 
 Other than that, `CR`, `LF` and white-space within the string
 is passed through as-is.
@@ -190,18 +243,17 @@ where a normal string is used as matching reference
 assumes that the source code has `LF`-only newlines,
 such as:
 
-    "\nX" = """
-        
-        X
-        """"
+    """
+    
+    X
+    """ = "\nX"
 
-If the source code has `CR` `LF` newlines that
-example instead becomes:
+If the source code has `CR LF` newlines that example instead becomes:
 
-    "\r\nX" = """
-        
-        X
-        """"
+    """
+    
+    X
+    """ = "\r\nX"
 
 ### Leading and trailing newline
 
@@ -209,28 +261,29 @@ The rules above strips one leading and one trailing newline.
 This is a simple convention that also gives control over
 the string's content:
 
-    "\n  X\n" = """
-        
-          X
-        
-        """,
+    """
     
-    "X" = """
-        X
-        """,
+      X
     
-    "" = """
-         
-         """
+    """ = "\n  X\n",
+    
+    """
+    X
+    """ = "X",
+    
+    """
+     
+    """ = ""
 
 Note that the following could be a syntax error; too short
 multi-line string since trailing newline shall be stripped
 both from the starting line and from the last content line,
-so the content could be seen as less than empty.
-But it is more convenient to allow this as also an empty string:
+so the content could be seen as less than empty,
+but it is more convenient to regard that newline as doubly stripped,
+and allow this as also an empty string:
 
-    "" = """
-         """
+    """
+    """ = ""
 
 ### Indentation
 
@@ -265,8 +318,9 @@ determines the indentation.
     """,
     
     """
-    This will probably be a syntax error
-    since the ending line is not here"""
+    This is an incomplete string so the scanner will search forward
+    for the end, and the shell will block waiting for more lines,
+    since these quote characters are not a valid string ending: """
 
 ### Backwards incompatibility
 
@@ -330,7 +384,7 @@ from the suggestions in this EEP.
 
 ### Quoting of `"""`
 
-In the rules above there is no possibility to have `"""`
+With the rules above there is no possibility to have `"""`
 first on a line in a triple-quoted string.
 
 This would be allowed:
@@ -357,8 +411,8 @@ attribute where there is no string concatenation.
 
 We can either ignore the problem since it is only
 when placed first on a line that `"""` is a problem,
-or we can use the GitHub [Markdown][] trick to allow
-3 or more start characters and matching end characters
+or we can use the [GitHub Flavored Markdown][Markdown] trick
+to allow 3 or more start characters and matching end characters
 so this would be valid:
 
     X = """"
@@ -366,6 +420,36 @@ so this would be valid:
         and ends with:
         """
         """"
+
+### Comparison with Elixir
+
+[Elixir][] has got triple-quoted strings and names them *heredocs*.
+
+They are delimited with `"""` as in this suggestion and have
+got very nearly the same rules for start line, end line and indentation.
+Here are the known differences:
+
+* The last end of line is not stripped.
+* They produce UTF-8 encoded binaries, just like `"` quoted
+  strings also does in [Elixir][].
+* They accept escape sequences.
+* Newlines can be escaped.
+* There is an escape sequence `"\a"`.
+* They do not allow 3-or-more `"` string start, which is a
+  suggestion in this EEP
+* They accept [Sigils][], which allows the string to be verbatim
+  but then the final newline cannot be avoided.
+
+This EEP suggests triple-quoted strings that are as [Elixir][]'s
+*heredocs* without interpolation and escaping:
+
+    ~S"""
+    Heredoc without interpolation and escaping
+    """
+
+The [Elixir][] string has a final newline that this EEP suggests
+should always be removed, since without escape sequences
+there is no possibility to remove it.
 
 [EEP 59]: https://www.erlang.org/eeps/eep-0059
     "EEP 59: Module attributes for documentation"
@@ -378,6 +462,18 @@ so this would be valid:
 
 [Markdown]: https://github.github.com/gfm/
     "GitHub Flavored Markdown"
+
+[AsciiDoc]: https://asciidoc.org/
+    "AsciiDoc plain text markup language"
+
+[Elixir]: https://elixir-lang.org
+    "The Elixir programming language"
+
+[Sigils]: https://elixir-lang.org/getting-started/sigils.html
+    "Elixir Sigils"
+
+[Comparison with Elixir]: #comparison-with-elixir
+    "Comparison with Elixir"
 
 Copyright
 =========

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -6,19 +6,19 @@
     Erlang-Version: OTP-27
     Post-History:
 ****
-EEP 64: Verbatim Multi-line Indented Strings
+EEP 64: Triple-Quoted Strings
 ----
 
 Abstract
 ========
 
-This EEP proposes the introduction of Verbatim Multi-line Indented strings,
-*VMI Strings*, and defines their semantics.  The main benefit is to allow
-*multi-line* strings in an easy and useful (*indented*) way,
-similar to other languages, e.g. Elixir.
+This EEP proposes the introduction of *Triple-Quoted Strings*,
+and defines their semantics.  The main benefit is to allow
+multi-line strings in an easy and useful way,
+i.e. with indentation, similar to other languages, e.g. Elixir.
 
 Their first use case is for in-module documentation attributes
-containing [Markdown][] or similarly formatted text where *verbatim* text
+containing [Markdown][] or similarly formatted text where verbatim text
 is desirable since any documentation text format has its own notion
 of escape sequences which will collide with Erlang's escape sequences.
 
@@ -44,6 +44,14 @@ sequence into the actual content.
 In a documentation attribute as suggested in [EEP 59][],
 the indentation problem is not that pronounced because
 the documentation attribute itself is not much indented:
+
+    -doc "
+    First line
+    Second line with \"\\*not emphasized\\* Markdown\"
+    Third line".
+
+But it sure looks better with indentation and not having
+to quote the backslashes:
 
     -doc """
         First line
@@ -75,7 +83,7 @@ that consists of a `-` token, an atom, one value term and a full stop
     \\-/".
 
 A documentation attribute should have a string as its content term,
-and here we want to use our new and more convenient VMI String
+and here we want to use our new and more convenient triple-quoted string
 instead of a normal string:
 
     -doc """
@@ -85,22 +93,23 @@ instead of a normal string:
         \-/
         """.
 
-### VMI String Scanner Token
+### Triple-Quoted String Scanner Token
 
-A VMI String must be a token that the scanner recognizes as a string,
-which makes it suitable for a documentation attribute value term.
-It starts and ends with three double quotes: `"""`.
+A triple-quoted string must be a token that the scanner recognizes
+as a string, which makes it suitable for a documentation attribute
+value term.  It starts and ends with three double quotes: `"""`.
 
 Double quotes, `"`, are chosen because normal Erlang strings use them
 and this is just a new variant.  Since double quotes are used
-a VMI String shall, as a normal string, produce a list of codepoints.
+a triple-quoted string shall, as a normal string,
+produce a list of code-points.
 
-It would be more convenient if a VMI String produced an UTF-8 binary,
-but that would be a surprising feature for double quotes, and
-the documentation build process can work around this by converting
-the codepoint list (`string()`) into the needed binary chunk.
+It would be more convenient if a triple-quoted string produced
+an UTF-8 binary, but that would be a surprising feature for double quotes,
+and the documentation build process can work around this by converting
+the code-point list (`string()`) into the needed binary chunk.
 
-In source code a VMI String is valid in a binary,
+In source code a triple-quoted string is valid within a binary,
 so producing a Unicode binary is reasonably straightforward:
 
     X = <<"""
@@ -111,19 +120,20 @@ so producing a Unicode binary is reasonably straightforward:
 The extra overhead is not exhausting since this we are targeting
 multi-line strings here.
 
-As a future expansion it has been proposed to use prefixes
+As a future expansion it has been proposed to use sigils (prefixes)
 for specialized strings such as regular expressions,
 interpolated variables ([PR-7343][]), Unicode binary strings, etc.
-For example: `X = u"Tschüß"` for an UTF-8 encoded string.
+For example: `X = ~u"Tschüß"` for an UTF-8 encoded string.
 
-### VMI String Start
+### Triple-Quoted String Start
 
 After the starting `"""` only white-space is allowed
 up to the end of the line.
 
 As a possible future expansion we might allow a keyword here
 that shouldn't be part of the string content, but could be
-a hint for for syntax highlighting in the editor.
+a hint for e.g. syntax highlighting and indentation handling
+in an editor / pretty printer.
 
     -doc """ md
         Markdown content
@@ -135,33 +145,63 @@ for the string content on the line after the starting
 `"""` except that it should not search for an ending `"""`.
 
 A later step, preferably done by the parser, strips the
-characters up to and including the newline from the
-first line of the string.
+characters up to and including the newline from the string content.
 
 If any of these characters is not white-space,
 the parser reports a syntax error.
 
-### VMI String End
+### Triple-Quoted String End
 
 All bytes are collected as they are (verbatim) and becomes
-the VMI String content.
+the string content.
 
-A VMI String ends with newline followed by optional white-space
-and then by  `"""`.  This completes the scanner token.
+A triple-quoted string ends with newline followed by optional white-space
+and then `"""`.  This completes the scanner token.
 
 A later step, preferably done by the parser, uses the white-space
 on the ending line as the definition of the string's indentation
-and strips that white-space sequence from every line in the string,
-and strips the newline preceding the ending line.
+and strips that particular white-space sequence from every line
+in the string, and strips the newline preceding the ending line.
 
 If any of the lines do not start with the defined indentation
 either because the line is too short or if the prefix differs,
 the parser reports a syntax error.
 
-Requiring that all lines must have exactly the same white-space
-characters as indentation is a simple solution to not have
-to define how indentation white-space (tab vs. space) normalization
-should be done, and also seems like a reasonable requirement.
+Requiring that all lines must have exactly the same indentation
+characters is a simple solution to not have to define how indentation
+white-space (tab vs. space) normalization should be done,
+and also seems like a reasonable requirement.
+
+### `CR`, `LF` and White-space
+
+The characters `CR` - Unicode code-point value 13,
+`LF` - code-point 10, and white-space - as as defined
+in the Erlang scanner today, are handled as usual by the scanner,
+except that if the line preceding the ending line
+ends in `CR` `LF` then also the `CR` is interpreted
+as part of the newline and is stripped along with the `LF`.
+This is a convenience for systems with `CR` `LF` newlines.
+
+Other than that, `CR`, `LF` and white-space within the string
+is passed through as-is.
+
+This means that the examples in the following text
+where a normal string is used as matching reference
+assumes that the source code has `LF`-only newlines,
+such as:
+
+    "\nX" = """
+        
+        X
+        """"
+
+If the source code has `CR` `LF` newlines that
+example instead becomes:
+
+    "\r\nX" = """
+        
+        X
+        """"
 
 ### Leading and trailing newline
 
@@ -187,19 +227,10 @@ Note that the following could be a syntax error; too short
 multi-line string since trailing newline shall be stripped
 both from the starting line and from the last content line,
 so the content could be seen as less than empty.
-But it is more convenient to allow it as also an empty string:
+But it is more convenient to allow this as also an empty string:
 
     "" = """
          """
-
-The definition of newline and white-space is the same as
-the current in the scanner, but; when stripping the newline
-from the line preceding the ending line, a CR should also
-be stripped, if the line ends in CR LF.
-
-This is a convenience for systems where CR LF is used as newline.
-In most places in the scanner CR is treated as white-space,
-but in this case it would be inconvenient to not strip the CR.
 
 ### Indentation
 
@@ -207,33 +238,35 @@ The rules above facilitates indentation of the content
 to adhere to the surrounding code.  The ending line
 determines the indentation.
 
-    "This text\nhas no indentation" = """
+    """
+    This text
+    has no indentation
+    """ =
+        "This text\nhas no indentation",
+    
+    """
         This text
-        has no indentation
-        """,
+        has indentation
+    """ =
+        "    This text\n    has indentation",
     
-    "    This text\n    has indentation" = """
-            This text
-            has indentation
-        """,
-    
-    "  This text\nhas an indented first line" =
-        """
-          This text
-        has an indented first line
-        """,
+    """
+      This text
+    has an indented first line
+    """ =
+        "  This text\nhas an indented first line",
     
     """
     This is a syntax error (incorrect indentation)
         """,
-
+    
     """ This is a syntax error
     (non-white-space on start line)
     """,
-
+    
     """
     This will probably be a syntax error
-    since no ending line can be found"""
+    since the ending line is not here"""
 
 ### Backwards incompatibility
 
@@ -259,7 +292,7 @@ Which is equivalent to:
 
     X = "\n    X\n"
 
-But with the suggested VMI Strings the first
+But with the suggested triple-quoted strings the first
 code snippet would instead be equivalent to:
 
     X = "X"
@@ -298,30 +331,29 @@ from the suggestions in this EEP.
 ### Quoting of `"""`
 
 In the rules above there is no possibility to have `"""`
-first on a line in a VMI String.
+first on a line in a triple-quoted string.
 
 This would be allowed:
 
     -doc """
-        A VMI String starts with: """
+        A triple-quoted string starts with: """
         and ends with: """
         """.
 
-As long as `"""` isn't first on a line.
+As long as `"""` isn't first on a line.  Unfortunately
+that is a lie since the ending according to this EEP
+*should* be first on a line...
 
 It would be possible to work around in Erlang code:
 
     X = """
-        A VMI String starts with:
-        ""
-        """ """
-        "
+        A triple-quoted string starts with: """
         and ends with:
-        ""
-        """ "\""
+        
+        """ "\"\"\"".
 
 That is ugly, and it is not possible in a documentation
-attribute where string concatenation isn't allowed.
+attribute where there is no string concatenation.
 
 We can either ignore the problem since it is only
 when placed first on a line that `"""` is a problem,
@@ -330,8 +362,7 @@ or we can use the GitHub [Markdown][] trick to allow
 so this would be valid:
 
     X = """"
-        A VMI String starts with:
-        """
+        A triple-quoted string starts with: """
         and ends with:
         """
         """"


### PR DESCRIPTION
This EEP discusses the design of the triple-quoted binary strings.

In the case that document attributes [EEP 59](https://www.erlang.org/eeps/eep-0059) and interpolation strings ([EEP 62](https://github.com/erlang/eep/pull/45)) are added before this EEP, interpolation attributes are to be disallowed in documentation attributes (this is mentioned in the EEP).

The semantics should feel familiar for Elixir developers, and should be pretty close to Elixir triple-quote semantics.

Feedback is welcome.
