### PR TITLE
Update record names as reserved words/variables and new record definition syntax

### DIFF
--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -230,8 +230,8 @@ defining records. Since usage of the syntax for getting, setting, matching, etc
 (e.g. `#rec{a=x,y=b}`) occurs far more commonly than defining, it only feels
 natural that the definition syntax would mirror usage.
 
-Further, the syntax in Erlang's type system to define records also matches the
-newly proposed define syntax.
+For more symmetry, the syntax in Erlang's type system to define records also
+matches the newly proposed define syntax.
 
 Thus, I feel that sharing the existing usage and type syntax with the
 definition system would likely become the default/preferred way, and that the

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -10,8 +10,8 @@ EEP 72: Reserved words and Variables as record names, and enhancement to definit
 Abstract
 ========
 
-This EEP loosens some of the restrictions around record names such no longer is
-it necessary to quote record names when those records are named with reserved
+This EEP loosens some of the restrictions around record names to make it
+no longer necessary to quote them when they are named with reserved
 words (`#if` vs `#'if'`) or words with capitalized first characters (`#Hello`
 vs `#'Hello'`).
 

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -21,15 +21,15 @@ following record definitions would all be valid and identical:
 
 ```erlang
 -record('div', {a :: integer(), b :: integer()}).
--record #'div'{a :: integer(), b :: integer()}.
 -record #div{a :: integer(), b :: integer()}.
 ```
 
-The latter two are proposed new syntax.  The following would also be valid
+The latter one is proposed new syntax.  The following would also be valid
 and identical since parentheses are optional in attributes:
 
 ```erlang
 -record 'div', {a :: integer(), b :: integer()}.
+-record #'div'{a :: integer(), b :: integer()}.
 -record(#'div'{a :: integer(), b :: integer()}).
 -record(#div{a :: integer(), b :: integer()}).
 ```

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -43,6 +43,7 @@ names to be consistent with the rest of the language's use of atoms.
 All atoms in Erlang can be denoted with single quotes. Some examples:
 
 For example:
+
 ```erlang
 'foo'.
 'FOO'.

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -12,8 +12,8 @@ Abstract
 
 This EEP loosens some of the restrictions around record names to make it
 no longer necessary to quote them when they are named with reserved
-words (`#if` vs `#'if'`) or words with capitalized first characters (`#Hello`
-vs `#'Hello'`).
+words (`#if` vs `#'if'`) or words with capitalized first characters (terms that
+currently would be treated as variables, for example `#Hello` vs `#'Hello'`).
 
 This EEP also proposes to add a new record-like syntax to the record
 definitions (also adopting the above syntactical changes), so that the

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -196,6 +196,7 @@ the new syntax if your code uses the new syntax rules.
 
 Broader Concerns and Points of Discussion
 =========================================
+
 While the new definition syntax creates some degree of symmetry around record
 usage, there do remain some concerns and inconsistencies:
 

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -91,7 +91,7 @@ go() ->
 ```
 
 While this approach is consistent with atom usage in the language, for reserved
-words, this makes the record syntax *feel* inconsistent if you have a need for
+words and capitalized atoms, this makes the record syntax *feel* inconsistent if you have a need for
 naming a record with a reserved word (or term with a capital first letter). In
 this case, it almost guarantees a user won't use a record named 'if',
 'receive', 'fun', etc even though there may very well be a valid use case for
@@ -183,7 +183,7 @@ Implementation
 
 To update the syntax for using records, we can safely augment the parser to
 change its already existing record handling of `'#' atom '{' ... '}'` and `'#' atom '.' atom` into `'#' record_name '{' ... '}'` and `'#' record_name '.' atom`, and define
-`record_name` to be `atom`, `var`, or `reserver_word`.
+`record_name` to be `atom`, `var`, or `reserved_word`.
 
 To update the record definition syntax, we can simply add a few new
 modifications to the `attribute` Nonterminal to allow `'#' record_name` as name for the `record` attribute, instead of `atom` as for generic attributes.
@@ -222,6 +222,7 @@ should try to hide it. These are remaining concerns and inconsistencies:
    feel that the symmetry between the usage and the definition would likely
    become the default/preferred way, and that the original syntax remain for
    backwards compatibility.
+3. Another 
 
 Reference Implementation
 ========================

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -17,7 +17,7 @@ vs `#'Hello'`).
 
 This EEP also proposes to add a new record-like syntax to the record
 definitions (also adopting the above syntactical changes), so that the
-following record definitions would all be valid and identical:
+following record definitions would be valid and identical:
 
 ```erlang
 -record('div', {a :: integer(), b :: integer()}).

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -1,0 +1,147 @@
+    Author: Jesse Gumm <ja(at)gumm(dot)io>
+    Status: Draft
+    Type: Standards Track
+    Created: 08-Oct-2024
+    Post-History:
+****
+EEP 72: Reserved words and Variables as record names, and enhancement to definition syntax
+----
+
+Abstract
+========
+
+This EEP loosens some of the restrictions around record names such no longer is
+it necessary to quote record names when those records are named with reserved
+words (`#if` vs `#'if'`) or words with capitalized first characters (`#Hello`
+vs `#'Hello'`).
+
+```erlang
+#'if'{
+
+This EEP also proposes to add a new record-like syntax to the record
+definitions (also adopting the above syntactical changes), such that the
+following record definitions would be identical:
+
+```erlang
+-record('div', {a :: integer(), b :: integer()}).
+-record #'div'{a :: integer(), b :: integer()}.
+-record #div{a :: integer(), b :: integer()}.
+```
+
+Motivation
+==========
+
+Record names are atoms. As such, the current Erlang syntax requires the record
+names to be consistent with the rest of the language's use of atoms.
+
+All atoms in Erlang can be denoted with single-quotes. Some examples:
+
+For example:
+```erlang
+'foo'.
+'FOO'.
+'foo-bar`.
+```
+
+But, conveniently, simple atoms (all alphanumeric, underscores (`_`) or
+at-symbols (`@`) with the first character being a lower-case letter and not one
+of the 20+ reserved words), in all contexts can be invoked without the
+necessary wrapping quotes. Some examples:
+
+```erlang
+foo.
+
+```
+
+Conveniently, this also means that records named with simple atoms can be
+invoked and used without having to quote the atoms. For example:
+
+```erlang
+-record(foo, {a, b}).
+
+go() ->
+    X = #foo{a = 1, b = 2},
+    Y = X#foo{a = something_else},
+    Z = Y#foo.a,
+    ...
+```
+
+Unfortunately, that also means that records named with anything that doesn't
+fit the "simple atom" pattern must be wrapped in quotes in definition and
+usage. For example:
+
+```erlang
+-record('div', {a, b}).
+
+go() ->
+    X = #'div'{a = 1, b = 2},
+    Y = X#'div'{a = something_else},
+    Z = Y#'div'.a,
+    ...
+```
+
+While this approach is consistent with atom usage in the language, for reserved
+words, this makes the record syntax *feel* inconsistent if you have a need for
+naming a record with a reserved word (or term with a capital first letter).  In
+this case, it almost guarantees a user won't use a record named 'if',
+'recieve', 'fun', etc even though there may very well be a valid use-case for
+such a name.  The most common use-case that comes to mind from the Nitrogen Web
+Framework.  Since HTML has a `div` tag, Nitrogen (which represents HTML tags
+using Erlang records) should naturally have a `#div` record, however, due to
+'div' being a reserved word, the record `#panel` is used instead to save the
+programmer from having to invoke `#'div'`, which feels unnatural and awkward.
+
+Specification
+=============
+
+This EEP simplifies the above example by
+
+1. Allowing reserved words and variables to be used without quotes for record
+   names, and
+2. Simplifying the definition such that the syntax between record definition
+   and record usage becomes more consistent.
+
+With the changes from this EEP, the above code becomes:
+
+```erlang
+-record #div{a, b}.
+
+go() ->
+    X = #div{a = 1, b = 2},
+    Y = X#div{a = something_else},
+    Z = Y#div.a,
+    ...
+```
+
+Implementation
+==============
+
+To update the syntax for using records, we can safely augment the parser to
+change `# atom` to `# record_name` and define `record_name` to be either
+`atom`, `var`, or `reserved_word`.
+
+To update the record definition syntax, we can simply add a few new
+modifications to the `attribute` Nonterminal.
+
+Backwards Compatibility
+=======================
+
+As this EEP only adds new syntax, the vast majority existing codebases will
+still work, with the possible exception of AST/code analysis tools that are
+analyzing code using the new syntax.
+
+Syntax highlighting and code-completion tools may need to be updated to support
+the new syntax if your code uses the new syntax rules.
+
+Reference Implementation
+========================
+
+The reference implementation is provided in a form of pull-request on GitHub
+
+    https://github.com/erlang/otp/pull/7873
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -210,22 +210,32 @@ be handled as the atom tagged tuple it actually is. The question is where
 to draw the line where the record's true nature shows, and how hard we
 should try to hide it. These are remaining concerns and inconsistencies:
 
-1. Other functions that work with records like `is_record/2` or `record_info/1`
-   are not currently covered by any of the syntactical changes in this EEP, and
-   as such, it remains necessary to quote record names if they are not simple
-   atoms. For example: `is_record(X, div)` would still be a syntax error. So
-   there is still not true 100% symmetry.  Note that instead of using the
-   `is_record(X, 'div')` guard, matching on `#div{}` is probably more frequently used,
-   since it is terser and mostly regarded as more readable.
-2. This EEP introducing a new syntax for record definition could potentially
-   lead to some to wonder why the language has two rather different syntaxes
-   for defining records. Since usage of the syntax for getting, setting,
-   matching, etc (e.g. `#rec{a=x,y=b}`) occurs far more commonly than defining,
-   it only feels natural that the definition syntax would mirror usage. Thus, I
-   feel that the symmetry between the usage and the definition would likely
-   become the default/preferred way, and that the original syntax remain for
-   backwards compatibility.
-3. Another 
+Auxiliary Record Functions
+--------------------------
+
+Other functions that work with records like `is_record/2` or `record_info/1`
+are not currently covered by any of the syntactical changes in this EEP, and as
+such, it remains necessary to quote record names if they are not simple atoms.
+For example: `is_record(X, div)` would still be a syntax error. So there is
+still not true 100% symmetry.  Note that instead of using the
+`is_record(X, 'div')` guard, matching on `#div{}` is probably more frequently
+used, since it is terser and mostly regarded as more readable.
+
+Two Definition Syntaxes?
+------------------------
+
+This EEP introducing a new syntax for record definition could potentially lead
+to some to wonder why the language has two rather different syntaxes for
+defining records. Since usage of the syntax for getting, setting, matching, etc
+(e.g. `#rec{a=x,y=b}`) occurs far more commonly than defining, it only feels
+natural that the definition syntax would mirror usage.
+
+Further, the syntax in Erlang's type system to define records also matches the
+newly proposed define syntax.
+
+Thus, I feel that sharing the existing usage and type syntax with the
+definition system would likely become the default/preferred way, and that the
+original syntax remain for backwards compatibility.
 
 Reference Implementation
 ========================

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -15,12 +15,9 @@ it necessary to quote record names when those records are named with reserved
 words (`#if` vs `#'if'`) or words with capitalized first characters (`#Hello`
 vs `#'Hello'`).
 
-```erlang
-#'if'{
-
 This EEP also proposes to add a new record-like syntax to the record
 definitions (also adopting the above syntactical changes), such that the
-following record definitions would be identical:
+following record definitions would all be valid and identical:
 
 ```erlang
 -record('div', {a :: integer(), b :: integer()}).

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -82,7 +82,7 @@ While this approach is consistent with atom usage in the language, for reserved
 words, this makes the record syntax *feel* inconsistent if you have a need for
 naming a record with a reserved word (or term with a capital first letter).  In
 this case, it almost guarantees a user won't use a record named 'if',
-'recieve', 'fun', etc even though there may very well be a valid use-case for
+'receive', 'fun', etc even though there may very well be a valid use-case for
 such a name.  The most common use-case that comes to mind from the Nitrogen Web
 Framework.  Since HTML has a `div` tag, Nitrogen (which represents HTML tags
 using Erlang records) should naturally have a `#div` record, however, due to

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -25,7 +25,8 @@ following record definitions would be valid and identical:
 ```
 
 The latter one is proposed new syntax.  The following would also be valid
-and identical since parentheses are optional in attributes:
+and identical since parentheses are optional in attributes,
+and since atoms may be quoted even when not mandatory:
 
 ```erlang
 -record 'div', {a :: integer(), b :: integer()}.

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -32,8 +32,8 @@ and identical since parentheses are optional in attributes:
 -record(#'div'{a :: integer(), b :: integer()}).
 -record(#div{a :: integer(), b :: integer()}).
 ```
-Motivation
-==========
+Usage Syntax Motivation
+=======================
 
 Record names are atoms. As such, the current Erlang syntax requires the record
 names to be consistent with the rest of the language's use of atoms.
@@ -87,18 +87,21 @@ go() ->
 
 While this approach is consistent with atom usage in the language, for reserved
 words, this makes the record syntax *feel* inconsistent if you have a need for
-naming a record with a reserved word (or term with a capital first letter).  In
+naming a record with a reserved word (or term with a capital first letter). In
 this case, it almost guarantees a user won't use a record named 'if',
 'receive', 'fun', etc even though there may very well be a valid use-case for
-such a name.  The most common use-case that comes to mind from the Nitrogen Web
-Framework.  Since HTML has a `div` tag, Nitrogen (which represents HTML tags
+such a name. The most common use-case that comes to mind from the Nitrogen Web
+Framework. Since HTML has a `div` tag, Nitrogen (which represents HTML tags
 using Erlang records) should naturally have a `#div` record, however, due to
 'div' being a reserved word (the integer division operator), the record `#panel`
 is used instead to save the programmer from having to invoke `#'div'`,
 which feels unnatural and awkward.
 
-Specification
-=============
+Further, 
+
+
+Usage Syntax Specification
+==========================
 
 This EEP simplifies the above example by
 
@@ -108,6 +111,51 @@ This EEP simplifies the above example by
    and record usage becomes more consistent.
 
 With the changes from this EEP, the above code becomes:
+
+```erlang
+-record('div', {a, b}).
+
+go() ->
+    X = #div{a = 1, b = 2},
+    Y = X#div{a = something_else},
+    Z = Y#div.a,
+    ...
+```
+
+Definition Syntax Motivation
+============================
+
+While the updated example in the usage syntax specification makes the *using*
+of records cleaner, there remains one more inconsistency that can also be
+relatively easily solved. That is the record definition still also needing to
+quote record name, as the example above demonstrates (repeated here for
+convenience):
+
+```erlang
+-record('div', {a, b}).
+
+go() ->
+    X = #div{a = 1, b = 2},
+    Y = X#div{a = something_else},
+    Z = Y#div.a,
+    ...
+```
+So whereas the record definition needs to be thought of as `'div'`, the record
+usage no longer requires the quoted term 'div', which could certainly lead an
+Erlang non-veteran to wonder why 'div' needs to be quoted in the definition
+while other atom-looking terms don't.
+
+
+Definition Syntax Specification
+===============================
+
+Conveniently, there is a rather easy solution, and that's to
+allow the record usage syntax to also be used as the record definition.
+
+This EEP also then also adds a new record definition syntax, improving the
+symmetry between general record usage and record definition.
+
+The above example can fully then look like the following:
 
 ```erlang
 -record #div{a, b}.
@@ -138,6 +186,26 @@ analyzing code using the new syntax.
 
 Syntax highlighting and code-completion tools may need to be updated to support
 the new syntax if your code uses the new syntax rules.
+
+Broader Concerns and Points of Discussion
+=========================================
+While the new definition syntax creates some degree of symmetry around record
+usage, there do remain some concerns and inconsistencies:
+
+1. Other functions that work with records like `is_record/2` or `record_info/1`
+   are not currently covered by any of the syntactical changes in this EEP, and
+   as such, it remains necessary to quote record names if they are not simple
+   atoms. For example: `is_record(X, div)` would still be a syntax error. So
+   there is still not true 100% symmetry.
+2. This EEP introducing a new syntax for record definition could potentially
+   lead to some to wonder why the language has two rather different syntaxes
+   for defining records. Since usage of the syntax for getting, setting,
+   matching, etc (e.g. `#rec{a=x,y=b}`) occurs far more commonly than defining,
+   it only feels natural that the definition syntax would mirror usage. Thus, I
+   feel that the symmetry between the usage and the definition would likely
+   become the default/preferred way, and that the original syntax remain for
+   backwards compatibility.
+
 
 Reference Implementation
 ========================

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -38,7 +38,7 @@ Usage Syntax Motivation
 Record names are atoms. As such, the current Erlang syntax requires the record
 names to be consistent with the rest of the language's use of atoms.
 
-All atoms in Erlang can be denoted with single-quotes. Some examples:
+All atoms in Erlang can be denoted with single quotes. Some examples:
 
 For example:
 ```erlang
@@ -48,7 +48,7 @@ For example:
 ```
 
 But, conveniently, simple atoms (all alphanumeric, underscores (`_`) or
-at-symbols (`@`) with the first character being a lower-case letter and not one
+at symbols (`@`) with the first character being a lowercase letter and not one
 of the 20+ reserved words), in all contexts can be invoked without the
 necessary wrapping quotes. Some examples:
 
@@ -89,8 +89,8 @@ While this approach is consistent with atom usage in the language, for reserved
 words, this makes the record syntax *feel* inconsistent if you have a need for
 naming a record with a reserved word (or term with a capital first letter). In
 this case, it almost guarantees a user won't use a record named 'if',
-'receive', 'fun', etc even though there may very well be a valid use-case for
-such a name. The most common use-case that comes to mind from the Nitrogen Web
+'receive', 'fun', etc even though there may very well be a valid use case for
+such a name. The most common use case that comes to mind from the Nitrogen Web
 Framework. Since HTML has a `div` tag, Nitrogen (which represents HTML tags
 using Erlang records) should naturally have a `#div` record, however, due to
 'div' being a reserved word (the integer division operator), the record `#panel`
@@ -142,8 +142,8 @@ go() ->
 ```
 So whereas the record definition needs to be thought of as `'div'`, the record
 usage no longer requires the quoted term 'div', which could certainly lead an
-Erlang non-veteran to wonder why 'div' needs to be quoted in the definition
-while other atom-looking terms don't.
+Erlang beginner to wonder why 'div' needs to be quoted in the definition while
+other atom-looking terms don't.
 
 
 Definition Syntax Specification
@@ -184,7 +184,7 @@ As this EEP only adds new syntax, the vast majority existing codebases will
 still work, with the possible exception of AST/code analysis tools that are
 analyzing code using the new syntax.
 
-Syntax highlighting and code-completion tools may need to be updated to support
+Syntax highlighting and code completion tools may need to be updated to support
 the new syntax if your code uses the new syntax rules.
 
 Broader Concerns and Points of Discussion
@@ -210,7 +210,7 @@ usage, there do remain some concerns and inconsistencies:
 Reference Implementation
 ========================
 
-The reference implementation is provided in a form of pull-request on GitHub
+The reference implementation is provided in a form of pull request on GitHub
 
     https://github.com/erlang/otp/pull/7873
 

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -24,7 +24,14 @@ following record definitions would all be valid and identical:
 -record #'div'{a :: integer(), b :: integer()}.
 -record #div{a :: integer(), b :: integer()}.
 ```
+The latter two are proposed new syntax.  The following would also be valid
+and identical since parentheses are optional in attributes:
 
+```erlang
+-record 'div', {a :: integer(), b :: integer()}.
+-record(#'div'{a :: integer(), b :: integer()}).
+-record(#div{a :: integer(), b :: integer()}).
+```
 Motivation
 ==========
 

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -93,8 +93,9 @@ this case, it almost guarantees a user won't use a record named 'if',
 such a name.  The most common use-case that comes to mind from the Nitrogen Web
 Framework.  Since HTML has a `div` tag, Nitrogen (which represents HTML tags
 using Erlang records) should naturally have a `#div` record, however, due to
-'div' being a reserved word, the record `#panel` is used instead to save the
-programmer from having to invoke `#'div'`, which feels unnatural and awkward.
+'div' being a reserved word (the integer division operator), the record `#panel`
+is used instead to save the programmer from having to invoke `#'div'`,
+which feels unnatural and awkward.
 
 Specification
 =============

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -182,11 +182,14 @@ Implementation
 ==============
 
 To update the syntax for using records, we can safely augment the parser to
-change its already existing record handling of `'#' atom '{' ... '}'` and `'#' atom '.' atom` into `'#' record_name '{' ... '}'` and `'#' record_name '.' atom`, and define
-`record_name` to be `atom`, `var`, or `reserved_word`.
+change its already existing record handling of `'#' atom '{' ... '}'` and
+`'#'atom '.' atom` into `'#' record_name '{' ... '}'` and
+`'#' record_name '.' atom`, and define `record_name` to be `atom`, `var`, or
+`reserved_word`.
 
 To update the record definition syntax, we can simply add a few new
-modifications to the `attribute` Nonterminal to allow `'#' record_name` as name for the `record` attribute, instead of `atom` as for generic attributes.
+modifications to the `attribute` Nonterminal to allow `'#' record_name` as name
+for the `record` attribute, instead of `atom` as for generic attributes.
 
 Backwards Compatibility
 =======================

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -66,11 +66,12 @@ invoked and used without having to quote the atoms. For example:
 
 ```erlang
 -record(foo, {a, b}).
+-record(bar, {c}).
 
 go() ->
     X = #foo{a = 1, b = 2},
     Y = X#foo{a = something_else},
-    Z = Y#foo.a,
+    Z = #bar{c = Y#foo.a},
     ...
 ```
 
@@ -80,11 +81,12 @@ usage. For example:
 
 ```erlang
 -record('div', {a, b}).
+-record('SET', {c}).
 
 go() ->
     X = #'div'{a = 1, b = 2},
     Y = X#'div'{a = something_else},
-    Z = Y#'div'.a,
+    Z = #'SET'{c = Y#'div'.a},
     ...
 ```
 
@@ -122,11 +124,12 @@ With the changes from this EEP, the above code becomes:
 
 ```erlang
 -record('div', {a, b}).
+-record('SET', {c}).
 
 go() ->
     X = #div{a = 1, b = 2},
     Y = X#div{a = something_else},
-    Z = Y#div.a,
+    Z = #SET{c = Y#div.a},
     ...
 ```
 
@@ -179,11 +182,11 @@ Implementation
 ==============
 
 To update the syntax for using records, we can safely augment the parser to
-change `# atom` to `# record_name` and define `record_name` to be either
-`atom`, `var`, or `reserved_word`.
+change its already existing record handling of `'#' atom '{' ... '}'` and `'#' atom '.' atom` into `'#' record_name '{' ... '}'` and `'#' record_name '.' atom`, and define
+`record_name` to be `atom`, `var`, or `reserver_word`.
 
 To update the record definition syntax, we can simply add a few new
-modifications to the `attribute` Nonterminal.
+modifications to the `attribute` Nonterminal to allow `'#' record_name` as name for the `record` attribute, instead of `atom` as for generic attributes.
 
 Backwards Compatibility
 =======================
@@ -199,13 +202,18 @@ Broader Concerns and Points of Discussion
 =========================================
 
 While the new definition syntax creates some degree of symmetry around record
-usage, there do remain some concerns and inconsistencies:
+usage, perfect symmetry is impossible to achieve, since a record can always
+be handled as the atom tagged tuple it actually is. The question is where
+to draw the line where the record's true nature shows, and how hard we
+should try to hide it. These are remaining concerns and inconsistencies:
 
 1. Other functions that work with records like `is_record/2` or `record_info/1`
    are not currently covered by any of the syntactical changes in this EEP, and
    as such, it remains necessary to quote record names if they are not simple
    atoms. For example: `is_record(X, div)` would still be a syntax error. So
-   there is still not true 100% symmetry.
+   there is still not true 100% symmetry.  Note that instead of using the
+   `is_record(X, 'div')` guard, matching on `#div{}` is probably more frequently used,
+   since it is terser and mostly regarded as more readable.
 2. This EEP introducing a new syntax for record definition could potentially
    lead to some to wonder why the language has two rather different syntaxes
    for defining records. Since usage of the syntax for getting, setting,

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -16,7 +16,7 @@ words (`#if` vs `#'if'`) or words with capitalized first characters (`#Hello`
 vs `#'Hello'`).
 
 This EEP also proposes to add a new record-like syntax to the record
-definitions (also adopting the above syntactical changes), such that the
+definitions (also adopting the above syntactical changes), so that the
 following record definitions would all be valid and identical:
 
 ```erlang

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -24,6 +24,7 @@ following record definitions would all be valid and identical:
 -record #'div'{a :: integer(), b :: integer()}.
 -record #div{a :: integer(), b :: integer()}.
 ```
+
 The latter two are proposed new syntax.  The following would also be valid
 and identical since parentheses are optional in attributes:
 
@@ -32,6 +33,7 @@ and identical since parentheses are optional in attributes:
 -record(#'div'{a :: integer(), b :: integer()}).
 -record(#div{a :: integer(), b :: integer()}).
 ```
+
 Usage Syntax Motivation
 =======================
 
@@ -105,7 +107,6 @@ application. (The previous link points to some record definitions in `asn1`,
 but you can see the usage scattered across a number of modules in the `asn1`
 application).
 
-
 Usage Syntax Specification
 ==========================
 
@@ -146,11 +147,11 @@ go() ->
     Z = Y#div.a,
     ...
 ```
+
 So whereas the record definition needs to be thought of as `'div'`, the record
 usage no longer requires the quoted term 'div', which could certainly lead an
 Erlang beginner to wonder why 'div' needs to be quoted in the definition while
 other atom-looking terms don't.
-
 
 Definition Syntax Specification
 ===============================
@@ -212,7 +213,6 @@ usage, there do remain some concerns and inconsistencies:
    become the default/preferred way, and that the original syntax remain for
    backwards compatibility.
 
-
 Reference Implementation
 ========================
 
@@ -224,4 +224,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -37,7 +37,7 @@ For example:
 ```erlang
 'foo'.
 'FOO'.
-'foo-bar`.
+'foo-bar'.
 ```
 
 But, conveniently, simple atoms (all alphanumeric, underscores (`_`) or
@@ -47,7 +47,8 @@ necessary wrapping quotes. Some examples:
 
 ```erlang
 foo.
-
+foo_Bar.
+'foo-bar'. % still quoted since the term has a non-atomic character in it.
 ```
 
 Conveniently, this also means that records named with simple atoms can be

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -97,7 +97,13 @@ using Erlang records) should naturally have a `#div` record, however, due to
 is used instead to save the programmer from having to invoke `#'div'`,
 which feels unnatural and awkward.
 
-Further, 
+Further, applications such as ASN.1 and Corba both have naming conventions that
+rely heavily on uppercase record names and as such, they currently must be
+quoted as well. You can see this in modules in Erlang's
+[`asn1`](https://github.com/erlang/otp/blob/OTP-27.1.1/lib/asn1/src/asn1_records.hrl#L35-L39)
+application. (The previous link points to some record definitions in `asn1`,
+but you can see the usage scattered across a number of modules in the `asn1`
+application).
 
 
 Usage Syntax Specification

--- a/eeps/eep-0072.md
+++ b/eeps/eep-0072.md
@@ -10,10 +10,10 @@ EEP 72: Reserved words and Variables as record names, and enhancement to definit
 Abstract
 ========
 
-This EEP loosens some of the restrictions around record names to make it
-no longer necessary to quote them when they are named with reserved
-words (`#if` vs `#'if'`) or words with capitalized first characters (terms that
-currently would be treated as variables, for example `#Hello` vs `#'Hello'`).
+This EEP loosens some of the restrictions around record names to make it no
+longer necessary to quote them when they are named with reserved words (`#if`
+vs `#'if'`) or words with capitalized first characters (terms that currently
+would be treated as variables, for example `#Hello` vs `#'Hello'`).
 
 This EEP also proposes to add a new record-like syntax to the record
 definitions (also adopting the above syntactical changes), so that the
@@ -24,9 +24,9 @@ following record definitions would be valid and identical:
 -record #div{a :: integer(), b :: integer()}.
 ```
 
-The latter one is proposed new syntax.  The following would also be valid
-and identical since parentheses are optional in attributes,
-and since atoms may be quoted even when not mandatory:
+The latter one is proposed new syntax.  The following would also be valid and
+identical since parentheses are optional in attributes, and since atoms may be
+quoted even when not mandatory:
 
 ```erlang
 -record 'div', {a :: integer(), b :: integer()}.


### PR DESCRIPTION
Hello,

This is in reference to [PR-7873](https://github.com/erlang/otp/pull/7873) and is made on @RaimoNiskanen's [recommendation](https://github.com/erlang/otp/pull/7873#issuecomment-2346314677).

@RaimoNiskanen, I did not include you as an author on the EEP, but since you implemented the new record syntax, you obviously deserve to be on it.  I just didn't want to include you without your blessing first.