### PR TITLE
Update EEPs have more consistent header contents

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,13 +12,20 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: DavidAnson/markdownlint-cli2-action@v14
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v17
         with:
           config: 'eep.markdownlint.json'
           globs: |
             README.md
             eeps/*.md
+      - name: Build html using Gruber MD
+        run: |
+            ./build.pl
+            ## Check for warnings by build.pl
+            if grep '<h2>Warnings</h2>' > /dev/null; then
+                exit 1
+            fi
       - name: Deploy on erlang.org
         if: github.ref == 'refs/heads/master'
         env:

--- a/eep-index.pl
+++ b/eep-index.pl
@@ -164,7 +164,7 @@ sub set_author {
 }
 
 sub set_status {
-    m|^ ([^/]*) (/? [^\s]*) \s* (.*)|x;
+    m|^ ([^/]*) (/? [^\s]*) \s* ([^;]*)|x;
     my ($status, $tag, $desc) = ($1, $2, $3);
     my $s = $status_map{lc $status};
     unless (defined $s) {

--- a/eep-index.pl
+++ b/eep-index.pl
@@ -43,7 +43,7 @@ my @status =
      'Draft' => '',
      'Accepted' => 'A',
      'Rejected' => 'R',
-     'Withdrawn' => 'W',
+     'Replaced' => 'P',
      'Deferred' => 'D',
      'Final' => 'F',
      );

--- a/eep-index.pl
+++ b/eep-index.pl
@@ -196,7 +196,7 @@ sub set_type {
 }
 
 # Mapping of EEP header tag to handler set_* function
-my %key =
+my %set =
     ('eep' => \&set_eep,
      'title' => \&set_title,
      'version' => 0,
@@ -216,12 +216,12 @@ my %key =
 
 sub store_key {
     my ($hash, $key, $value) = @_;
-    unless (defined $key{$key}) {
+    unless (defined $set{$key}) {
 	push 
 	    @warnings, 
 	    "File $file: '$key:' unknown header - file skipped!";
     }
-    if ($key{$key}) {
+    if ($set{$key} || $check{$key}) {
 	if (defined $$hash{$key}) {
 	    push 
 		@warnings, 
@@ -286,8 +286,8 @@ while ($file = readdir DIR) {
 	} elsif ($line =~ m|^\s*$|) { # blank line
 	    # end of headers - process them all
 	    next LINE unless defined($hdr{'eep'}); # still missing?
-	    foreach (keys %key) {
-		if ($key{$_} and !(defined $hdr{$_})) {
+	    foreach (keys %set) {
+		if ($set{$_} and !(defined $hdr{$_})) {
 		    push
 			@warnings,
 			"File $file: '$_:' missing header - file skipped!";
@@ -296,7 +296,7 @@ while ($file = readdir DIR) {
 	    }
 	    # call handler for all headers
 	    while (($key, $_) = each %hdr) {
-		&{$key{$key}};
+		&{$set{$key}} if $set{$key};
 	    }
 	    last LINE;
 	} else {

--- a/eep-index.pl
+++ b/eep-index.pl
@@ -214,6 +214,35 @@ my %set =
      'replaced-by' => 0,
      );
 
+sub check_erlang_version {
+    my $version = $_;
+    if (defined($version)) {
+        push @warnings, "File $file: 'version: $version' illegal!"
+            unless $version =~ /OTP_R[0-9]+[AB]([-][0-9])?/ || $version =~ /OTP-([0-9]+)[.]/;
+    } elsif ($status{$file} =~ /^F\//) {
+        push @warnings, "File $file: 'version: EEPs in status Final must have an Erlang-Version!";
+    }
+}
+
+# Mapping of EEP header tag to handler check_* function
+my %check =
+    ('eep' => 0,
+     'title' => 0,
+     'version' => 0,
+     'last-modified' => 0,
+     'author' => 0,
+     'discussions-to' => 0,
+     'status' => 0,
+     'type' => 0,
+     'content-type' => 0,
+     'requires' => 0,
+     'created' => 0,
+     'erlang-version' => \&check_erlang_version,
+     'post-history' => 0,
+     'replaces' => 0,
+     'replaced-by' => 0,
+     );
+
 sub store_key {
     my ($hash, $key, $value) = @_;
     unless (defined $set{$key}) {
@@ -298,6 +327,12 @@ while ($file = readdir DIR) {
 	    while (($key, $_) = each %hdr) {
 		&{$set{$key}} if $set{$key};
 	    }
+
+            # call checks for all headers
+	    while (($key, $_) = each %hdr) {
+		&{$check{$key}} if $check{$key};
+	    }
+
 	    last LINE;
 	} else {
 	    push

--- a/eep-index.pl
+++ b/eep-index.pl
@@ -369,7 +369,7 @@ while (<INDEX>) {
 #
 if (@warnings) {
     print "${lf}${lf}${lf}----${lf}Warnings${lf}--------${lf}";
-    foreach (@warnings) {
+    foreach (sort @warnings) {
 	print "    $_";
     }
 }

--- a/eeps/eep-0001.md
+++ b/eeps/eep-0001.md
@@ -272,8 +272,9 @@ versions of the EEP are posted to erlang-questions.  Both headers
 should be in dd-mmm-yyyy format, e.g. 14-Aug-2009.
 
 Standards Track EEPs must have a Erlang-Version header which indicates
-the version of Erlang that the feature will be released with.  Process
-EEPs do not need a Erlang-Version header.
+the version of Erlang that the feature will or has be released with.  
+Process EEPs do not need a Erlang-Version header. The version must be
+in the same format as the git tag scheme of Erlang/OTP project.
 
 EEPs may have a Requires header, indicating the EEP numbers that this
 EEP depends on..

--- a/eeps/eep-0004.md
+++ b/eeps/eep-0004.md
@@ -2,7 +2,7 @@
     Status: Final/R12B-0 Proposal is implemented in OTP release R12B-0
     Type: Standards Track
     Created: 10-Aug-2007
-    Erlang-Version: R12B-0
+    Erlang-Version: OTP_R12B-0
     Post-History:
 ****
 EEP 4: New BIFs for bit-level binaries (bit strings)

--- a/eeps/eep-0005.md
+++ b/eeps/eep-0005.md
@@ -3,7 +3,7 @@
     Status: Draft
     Type: Standards Track
     Created: 10-Aug-2007
-    Erlang-Version: R12B-0
+    Erlang-Version: OTP_R12B-0
     Post-History:
 ****
 EEP 5: More Versatile Encapsulation with `export_to`

--- a/eeps/eep-0006.md
+++ b/eeps/eep-0006.md
@@ -2,7 +2,7 @@
     Status: Final/R12B-0 Proposal is implemented in OTP release R12B-0
     Type: Standards Track
     Created: 10-Aug-2007
-    Erlang-Version: R12B-0
+    Erlang-Version: OTP_R12B-0
     Post-History:
 ****
 EEP 6: New BIFs for tuple and binary sizes

--- a/eeps/eep-0007.md
+++ b/eeps/eep-0007.md
@@ -2,7 +2,7 @@
     Status: Rejected
     Type: Standards Track
     Created: 3-Sep-2007
-    Erlang-Version: R12B
+    Erlang-Version: OTP_R12B
     Post-History:
 ****
 EEP 7: Foreign Function Interface (FFI)

--- a/eeps/eep-0008.md
+++ b/eeps/eep-0008.md
@@ -3,7 +3,7 @@
     Status: Final/R13B03 Proposal documented and implemented in OTP R13B03
     Type: Standards Track
     Created: 2-Dec-2007
-    Erlang-Version: R12B
+    Erlang-Version: OTP_R12B
     Post-History:
 ****
 EEP 8: Types and function specifications

--- a/eeps/eep-0009.md
+++ b/eeps/eep-0009.md
@@ -2,7 +2,7 @@
     Status: Final/R-34 Replaced with EEP-11 and EEP-31 except `binary_string` which is part of a new `string` implementation
     Type: Standards Track
     Created: 28-Dec-2007
-    Erlang-Version: R12B-2
+    Erlang-Version: OTP_R12B-2
     Post-History:
 ****
 EEP 9: Library for working with binaries

--- a/eeps/eep-0010.md
+++ b/eeps/eep-0010.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 07-may-2008
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Post-History: 01-jan-1970
 ****
 EEP 10: Representing Unicode characters in Erlang

--- a/eeps/eep-0011.md
+++ b/eeps/eep-0011.md
@@ -3,7 +3,7 @@
      except for Unicode support according to EEP 10
     Type: Standards Track
     Created: 04-Jun-2008
-    Erlang-Version: R12B-5
+    Erlang-Version: OTP_R12B-5
     Post-History: 01-Jan-1970
 ****
 EEP 11: Built in regular expressions in Erlang

--- a/eeps/eep-0012.md
+++ b/eeps/eep-0012.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 10-Jul-2008
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Post-History:
 ****
 EEP 12: Extensions to comprehensions

--- a/eeps/eep-0013.md
+++ b/eeps/eep-0013.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 09-Jul-2008
     Post-History:
 ****

--- a/eeps/eep-0014.md
+++ b/eeps/eep-0014.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 10-Jul-2008
     Post-History:
 ****

--- a/eeps/eep-0015.md
+++ b/eeps/eep-0015.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 15-Jul-2008
     Post-History:
 ****

--- a/eeps/eep-0016.md
+++ b/eeps/eep-0016.md
@@ -181,12 +181,13 @@ it would be easier to add this than to write it up.
 
 Here's some text to go in the documentation:
 
+<!-- markdownlint-disable MD027 -->
 >     is_integer(Term, LB, UB) -> bool()
->
+> 
 >     Types:
->         Term = term()
->         LB = integer()
->         UB = integer()
+>        Term = term()
+>        LB = integer()
+>        UB = integer()
 >
 > Returns true if Term is an integer lying between LB
 > and UB inclusive (LB =< Term, Term =< UB); otherwise

--- a/eeps/eep-0016.md
+++ b/eeps/eep-0016.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 23-Jul-2008
     Post-History:
 ****

--- a/eeps/eep-0017.md
+++ b/eeps/eep-0017.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 23-Jul-2008
     Post-History:
 ****

--- a/eeps/eep-0018.md
+++ b/eeps/eep-0018.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Replaced
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 28-Jul-2008
     Post-History:
     Replaced-By: EEP-0068

--- a/eeps/eep-0019.md
+++ b/eeps/eep-0019.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 14-Aug-2008
     Post-History:
 ****

--- a/eeps/eep-0020.md
+++ b/eeps/eep-0020.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 05-Aug-2008
     Post-History:
 ****

--- a/eeps/eep-0021.md
+++ b/eeps/eep-0021.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 08-Aug-2008
     Post-History:
 ****

--- a/eeps/eep-0022.md
+++ b/eeps/eep-0022.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 27-Aug-2008
     Post-History:
 ****

--- a/eeps/eep-0023.md
+++ b/eeps/eep-0023.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Final/R12B-4  Implemented in OTP release R12B-4
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 08-Aug-2008
     Post-History:
 ****

--- a/eeps/eep-0024.md
+++ b/eeps/eep-0024.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Final/R12B-5  Implemented in OTP release R12B-5
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 22-Sep-2008
     Post-History:
 ****

--- a/eeps/eep-0025.md
+++ b/eeps/eep-0025.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 28-Nov-2008
     Post-History:
 ****

--- a/eeps/eep-0026.md
+++ b/eeps/eep-0026.md
@@ -1,7 +1,7 @@
     Author: Björn Gustavsson <bjorn(at)erlang(dot)org>
     Status: Accepted/R13A  Implemented in OTP release R13A
     Type: Standards Track
-    Erlang-Version: R12B-5
+    Erlang-Version: OTP_R12B-5
     Created: 28-Jan-2009
     Post-History:
 ****

--- a/eeps/eep-0028.md
+++ b/eeps/eep-0028.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 08-Aug-2008
     Post-History:
 ****

--- a/eeps/eep-0029.md
+++ b/eeps/eep-0029.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R12B-5
+    Erlang-Version: OTP_R12B-5
     Created: 25-Feb-2009
     Post-History:
 ****

--- a/eeps/eep-0030.md
+++ b/eeps/eep-0030.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Final/R13A/R14A  Implemented in OTP release R13A and R14A
     Type: Standards Track
-    Erlang-Version: R12B-4
+    Erlang-Version: OTP_R12B-4
     Created: 10-Jul-2008
     Post-History:
 ****

--- a/eeps/eep-0031.md
+++ b/eeps/eep-0031.md
@@ -3,7 +3,7 @@
     Status:         Final/R14A  Implemented in OTP release R14A
     Type:           Standards Track
     Created:        28-Nov-2009
-    Erlang-Version: R13B03
+    Erlang-Version: OTP_R13B03
     Post-History:
 ****
 EEP 31: Binary manipulation and searching module

--- a/eeps/eep-0032.md
+++ b/eeps/eep-0032.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 09-Feb-2010
-    Erlang-Version: R13B-3
+    Erlang-Version: OTP_R13B-3
     Post-History:
 ****
 EEP 32: Module-local process names

--- a/eeps/eep-0033.md
+++ b/eeps/eep-0033.md
@@ -84,9 +84,9 @@ directions below.
   header and set the value to the next planned version of Erlang, i.e.
   the one your new feature will hopefully make its first appearance in.
   Thus, if the last version of Erlang/OTP was R13B-3 and you're hoping
-  to get your new feature into R13B-4 set the version header to:
+  to get your new feature into 28.0 set the version header to:
 
-        Erlang-Version: R13B-4
+        Erlang-Version: OTP-28.0
 
 - Leave Post-History alone for now; you'll add dates to this header each
   time you post your EEP to <erlang-questions@erlang.org>.  E.g. if you

--- a/eeps/eep-0034.md
+++ b/eeps/eep-0034.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 31-Aug-2010
-    Erlang-Version: R14B
+    Erlang-Version: OTP_R14B
     Post-History:
 ****
 EEP 34: Extended basic packet options for decode_packet

--- a/eeps/eep-0035.md
+++ b/eeps/eep-0035.md
@@ -3,7 +3,7 @@
     Status: Draft
     Type: Standards Track
     Created: 29-Sep-2010
-    Erlang-Version: R14B
+    Erlang-Version: OTP_R14B
     Post-History:
     Replaces: 9
 ****

--- a/eeps/eep-0036.md
+++ b/eeps/eep-0036.md
@@ -2,7 +2,7 @@
     Status: Final/R15B  Implemented in OTP release R15B
     Type: Standards Track
     Created: 01-Mar-2011
-    Erlang-Version: R15A
+    Erlang-Version: OTP_R15B
     Post-History:
 ****
 EEP 36: Line numbers in exceptions

--- a/eeps/eep-0037.md
+++ b/eeps/eep-0037.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status:Final/R15B  Implemented in OTP release R15B
     Type: Standards Track
-    Erlang-Version: R14B04
+    Erlang-Version: OTP_R14B04
     Content-Type: text/plain
     Created: 27-May-2011
     Post-History:

--- a/eeps/eep-0038.md
+++ b/eeps/eep-0038.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R14B04
+    Erlang-Version: OTP_R14B04
     Created: 27-May-2011
     Post-History:
 ****

--- a/eeps/eep-0039.md
+++ b/eeps/eep-0039.md
@@ -1,7 +1,7 @@
     Author: Yurii Rashkovskii <yrashk(at)gmail(dot)com>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R15A
+    Erlang-Version: OTP_R15A
     Created: 2-Jul-2011
     Post-History: 2-Jul-2011
 ****

--- a/eeps/eep-0040.md
+++ b/eeps/eep-0040.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-version: R15B02
+    Erlang-version: OTP_R15B02
     Created: 19-Oct-2012
     Post-History: 19-Oct-2012
 ****

--- a/eeps/eep-0041.md
+++ b/eeps/eep-0041.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R16A
+    Erlang-Version: OTP_R16A
     Created: 04-Feb-2013
     Post-History:
 ****

--- a/eeps/eep-0042.md
+++ b/eeps/eep-0042.md
@@ -1,7 +1,7 @@
     Author: Richard A. O'Keefe <ok(at)cs(dot)otago(dot)ac(dot)nz>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R16A
+    Erlang-Version: OTP_R16A
     Created: 07-Feb-2013
     Post-History:
 ****

--- a/eeps/eep-0043.md
+++ b/eeps/eep-0043.md
@@ -2,7 +2,7 @@
     Status:         Final/R17B  Implemented in OTP R17B (except ...)
     Type:           Standards Track
     Created:        04-Apr-2013
-    Erlang-Version: R17A
+    Erlang-Version: OTP-17.0
     Post-History:
 ***
 EEP 43: Maps

--- a/eeps/eep-0043.md
+++ b/eeps/eep-0043.md
@@ -1,5 +1,5 @@
     Author:         Björn-Egil Dahlberg <egil(at)Erlang.org>
-    Status:         Final/R17B  Implemented in OTP R17B (except ...)
+    Status:         Final/17.0  Implemented in OTP release 17
     Type:           Standards Track
     Created:        04-Apr-2013
     Erlang-Version: OTP-17.0

--- a/eeps/eep-0044.md
+++ b/eeps/eep-0044.md
@@ -3,7 +3,7 @@
             are implemented in OTP version 19.0
     Type: Standards Track
     Created: 30-Sep-2015
-    Erlang-Version: R19
+    Erlang-Version: OTP-19.0
     Post-History: 16-Oct-2015, 22-Oct-2015, 29-Oct-2015
 ****
 EEP 44: Additional preprocessor directives

--- a/eeps/eep-0044.md
+++ b/eeps/eep-0044.md
@@ -1,6 +1,6 @@
     Author: Björn Gustavsson <bjorn(at)erlang(dot)org>
     Status: Accepted/19.0-we  Proposal's -warning and -error directives
-            are implemented in OTP version 19.0
+            are implemented in OTP release 19
     Type: Standards Track
     Created: 30-Sep-2015
     Erlang-Version: OTP-19.0

--- a/eeps/eep-0045.md
+++ b/eeps/eep-0045.md
@@ -2,7 +2,7 @@
     Status: Accepted/19.0  Implemented in OTP version 19.0
     Type: Standards Track
     Created: 27-Oct-2015
-    Erlang-Version: R19
+    Erlang-Version: OTP-19.0
     Post-History: 29-Oct-2015, 09-Nov-2015, 11-Nov-2015, 16-Nov-2015
 ****
 EEP 45: New macros for function name and arity

--- a/eeps/eep-0045.md
+++ b/eeps/eep-0045.md
@@ -1,5 +1,5 @@
     Author: Björn Gustavsson <bjorn(at)erlang(dot)org>
-    Status: Accepted/19.0  Implemented in OTP version 19.0
+    Status: Accepted/19.0  Implemented in OTP release 19
     Type: Standards Track
     Created: 27-Oct-2015
     Erlang-Version: OTP-19.0

--- a/eeps/eep-0046.md
+++ b/eeps/eep-0046.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 06-Dec-2016
-    Erlang-Version: OTP 20.0
+    Erlang-Version: OTP-20.0
     Post-History: 6-Dec-2016
 ****
 EEP 46: B-trees: balanced search trees of order n

--- a/eeps/eep-0047.md
+++ b/eeps/eep-0047.md
@@ -1,5 +1,5 @@
     Author: Björn Gustavsson <bjorn(at)erlang(dot)org>
-    Status: Final/21.0  Implemented in OTP version 21.0
+    Status: Final/21.0  Implemented in OTP release 21
     Type: Standards Track
     Created: 23-Nov-2017
     Erlang-Version: OTP-21.0

--- a/eeps/eep-0047.md
+++ b/eeps/eep-0047.md
@@ -2,7 +2,7 @@
     Status: Final/21.0  Implemented in OTP version 21.0
     Type: Standards Track
     Created: 23-Nov-2017
-    Erlang-Version: 21
+    Erlang-Version: OTP-21.0
     Post-History: 24-Nov-2017, 30-Nov-2017
 ****
 EEP 47: Add syntax in try/catch to retrieve the stacktrace directly

--- a/eeps/eep-0048.md
+++ b/eeps/eep-0048.md
@@ -1,7 +1,7 @@
     Author: José Valim <jose(dot)valim(at)gmail(dot)com>,
             Eric Bailey,
             Radek Szymczyszyn
-    Status: Final/24.0  Implemented in OTP version 24.0
+    Status: Final/24.0  Implemented in OTP release 24
     Type: Standards Track
     Created: 04-Jan-2018
     Post-History: 

--- a/eeps/eep-0049.md
+++ b/eeps/eep-0049.md
@@ -1,7 +1,7 @@
     Author: Fred Hebert <mononcqc(at)ferd(dot)ca>
     Status: Final/25.0  Implemented in OTP version 25.0
     Type: Standards Track
-    Erlang-Version: 25.0
+    Erlang-Version: OTP-25.0
     Created: 31-Aug-2018
     Post-History: 05-Dec-2020, 02-Nov-2021, 17-Nov-2021
 ****

--- a/eeps/eep-0049.md
+++ b/eeps/eep-0049.md
@@ -1,5 +1,5 @@
     Author: Fred Hebert <mononcqc(at)ferd(dot)ca>
-    Status: Final/25.0  Implemented in OTP version 25.0
+    Status: Final/25.0  Implemented in OTP release 25
     Type: Standards Track
     Erlang-Version: OTP-25.0
     Created: 31-Aug-2018

--- a/eeps/eep-0050.md
+++ b/eeps/eep-0050.md
@@ -1,5 +1,5 @@
     Author: José Valim <jose(dot)valim(at)gmail(dot)com>
-    Status: Final/24.0  Implemented in OTP version 24.0
+    Status: Final/24.0 Implemented in OTP release 24
     Type: Standards Track
     Created: 18-Sep-2019
     Post-History:

--- a/eeps/eep-0051.md
+++ b/eeps/eep-0051.md
@@ -1,5 +1,5 @@
     Author: Sergey Prokhorov <seriy(dot)pr(at)gmail(dot)com>
-    Status: Accepted/23.0  Implemented in OTP release 23.0
+    Status: Accepted/23.0  Implemented in OTP release 23
     Type: Standards Track
     Erlang-Version: OTP-23.0
     Created: 07-Oct-2019

--- a/eeps/eep-0051.md
+++ b/eeps/eep-0051.md
@@ -1,7 +1,7 @@
     Author: Sergey Prokhorov <seriy(dot)pr(at)gmail(dot)com>
     Status: Accepted/23.0  Implemented in OTP release 23.0
     Type: Standards Track
-    Erlang-Version: 23.0
+    Erlang-Version: OTP-23.0
     Created: 07-Oct-2019
     Post-History:
 ****

--- a/eeps/eep-0052.md
+++ b/eeps/eep-0052.md
@@ -2,7 +2,7 @@
     Status: Accepted/23.0  Implemented in OTP version 23.0
     Type: Standards Track
     Created: 28-Jan-2020
-    Erlang-Version: 23
+    Erlang-Version: OTP-23.0
     Post-History: 28-Jan-2020
 ****
 EEP 52: Allow key and size expressions in map and binary matching

--- a/eeps/eep-0052.md
+++ b/eeps/eep-0052.md
@@ -1,5 +1,5 @@
     Author: Björn Gustavsson <bjorn(at)erlang(dot)org>
-    Status: Accepted/23.0  Implemented in OTP version 23.0
+    Status: Accepted/23.0  Implemented in OTP release 23
     Type: Standards Track
     Created: 28-Jan-2020
     Erlang-Version: OTP-23.0

--- a/eeps/eep-0053.md
+++ b/eeps/eep-0053.md
@@ -1,5 +1,5 @@
     Author: Rickard Green <rickard(at)erlang(dot)org>
-    Status: Final/24.0  Implemented in OTP version 24.0
+    Status: Final/24.0  Implemented in OTP release 24
     Type: Standards Track
     Erlang-Version: OTP-24.0
     Created: 01-Sept-2019

--- a/eeps/eep-0053.md
+++ b/eeps/eep-0053.md
@@ -1,7 +1,7 @@
     Author: Rickard Green <rickard(at)erlang(dot)org>
     Status: Final/24.0  Implemented in OTP version 24.0
     Type: Standards Track
-    Erlang-Version: 24.0
+    Erlang-Version: OTP-24.0
     Created: 01-Sept-2019
     Post-History:
 ****

--- a/eeps/eep-0054.md
+++ b/eeps/eep-0054.md
@@ -1,5 +1,5 @@
     Author: Björn Gustavsson <bjorn(at)erlang(dot)org>
-    Status: Final/24.0  Implemented in OTP version 24.0
+    Status: Final/24.0  Implemented in OTP release 24
     Type: Standards Track
     Created: 14-Sep-2020
     Erlang-Version: OTP-24.0

--- a/eeps/eep-0054.md
+++ b/eeps/eep-0054.md
@@ -2,7 +2,7 @@
     Status: Final/24.0  Implemented in OTP version 24.0
     Type: Standards Track
     Created: 14-Sep-2020
-    Erlang-Version: 24
+    Erlang-Version: OTP-24.0
     Post-History: 14-Oct-2020, 27-Nov-2020
 ****
 EEP 54: Provide more information about errors

--- a/eeps/eep-0055.md
+++ b/eeps/eep-0055.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 21-Dec-2020
-    Erlang-Version: 24
+    Erlang-Version: OTP-24.0
     Post-History: 24-Dec-2020
 ****
 EEP 55: Pinning operator ^ in patterns

--- a/eeps/eep-0056.md
+++ b/eeps/eep-0056.md
@@ -1,6 +1,6 @@
     Author: Maria Scott <maria-12648430(at)hnc-agency(dot)org>,
             Jan Uhlig <juhlig(at)hnc-agency(dot)org>
-    Status: Final/24.0 Implemented in OTP release 24.0
+    Status: Final/24.0 Implemented in OTP release 24
     Type: Standards Track
     Created: 04-Mar-2021
     Erlang-Version: OTP-24.0

--- a/eeps/eep-0056.md
+++ b/eeps/eep-0056.md
@@ -3,7 +3,7 @@
     Status: Final/24.0 Implemented in OTP release 24.0
     Type: Standards Track
     Created: 04-Mar-2021
-    Erlang-Version: 24.0
+    Erlang-Version: OTP-24.0
     Post-History: 08-Mar-2021, 17-Mar-2021, 23-Mar-2021, 31-Mar-2021,
                   https://github.com/erlang/otp/pull/4521
     Replaces:

--- a/eeps/eep-0057.md
+++ b/eeps/eep-0057.md
@@ -1,7 +1,7 @@
     Author: Serge Aleynikov <saleyn(at)gmail(dot)com>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: R24
+    Erlang-Version: OTP-24.0
     Created: 09-Jun-2021
     Post-History:
 ****

--- a/eeps/eep-0058.md
+++ b/eeps/eep-0058.md
@@ -2,7 +2,7 @@
     Status: Final/26.0 Implemented in OTP release 26.0
     Type: Standards Track
     Created: 14-Sep-2021
-    Erlang-Version: 25
+    Erlang-Version: OTP-26.0
     Post-History: 20-May-2021, https://github.com/erlang/otp/pull/4856
 ****
 EEP 58: Map comprehensions

--- a/eeps/eep-0058.md
+++ b/eeps/eep-0058.md
@@ -1,5 +1,5 @@
     Author: Sergey Prokhorov <seriy(dot)pr(at)gmail(dot)com>
-    Status: Final/26.0 Implemented in OTP release 26.0
+    Status: Final/26.0 Implemented in OTP release 26
     Type: Standards Track
     Created: 14-Sep-2021
     Erlang-Version: OTP-26.0

--- a/eeps/eep-0059.md
+++ b/eeps/eep-0059.md
@@ -1,5 +1,5 @@
     Author: José Valim <jose(dot)valim(at)gmail(dot)com>
-    Status: Final/27.0  Implemented in OTP version 27.0
+    Status: Final/27.0  Implemented in OTP release 27
     Type: Standards Track
     Created: 02-Jun-2021
     Post-History:

--- a/eeps/eep-0060.md
+++ b/eeps/eep-0060.md
@@ -1,7 +1,7 @@
     Author: Cons T Åhs <cons(at)erlang(dot)org>
     Status: Draft
     Type: Standards Track
-    Erlang-Version: OTP25
+    Erlang-Version: OTP-25.0
     Created: 4-Oct-2021
     Post-History:
 ****

--- a/eeps/eep-0061.md
+++ b/eeps/eep-0061.md
@@ -1,5 +1,5 @@
     Author: Ilya Klyuchnikov <ilya(dot)klyuchnikov(at)gmail(dot)com>
-    Status: Final/26.0 Implemented in OTP release 26.0
+    Status: Final/26.0 Implemented in OTP release 26
     Type: Standards Track
     Created: 08-Mar-2023
     Post-History: https://github.com/erlang/eep/pull/44

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -1,6 +1,6 @@
     Author: Raimo Niskanen <raimo(at)erlang(dot)org>,
             Kiko Fernandez-Reyes <kiko(at)erlang(dot)org>
-    Status: Final/27-w  Implemented in OTP version 27.0
+    Status: Final/27-w  Implemented in OTP release 27
             with a warning in OTP version 26.1
     Type: Standards Track
     Created: 07-Jun-2023

--- a/eeps/eep-0064.md
+++ b/eeps/eep-0064.md
@@ -4,7 +4,7 @@
             with a warning in OTP version 26.1
     Type: Standards Track
     Created: 07-Jun-2023
-    Erlang-Version: OTP-27
+    Erlang-Version: OTP-27.0
     Post-History:
         https://erlangforums.com/t/feature-heredocs-triple-quoted-text/2638/26
         https://github.com/erlang/otp/pull/7451

--- a/eeps/eep-0066.md
+++ b/eeps/eep-0066.md
@@ -1,5 +1,5 @@
     Author: Raimo Niskanen <raimo(at)erlang(dot)org>
-    Status: Final/27.0 Implemented in OTP version 27.0;
+    Status: Final/27.0 Implemented in OTP release 27;
             the regular expression sigils (`~r` and `~R`) are not implemented
     Type: Standards Track
     Created: 25-Sep-2023

--- a/eeps/eep-0066.md
+++ b/eeps/eep-0066.md
@@ -3,7 +3,7 @@
             the regular expression sigils (`~r` and `~R`) are not implemented
     Type: Standards Track
     Created: 25-Sep-2023
-    Erlang-Version: OTP-27
+    Erlang-Version: OTP-27.0
     Post-History:
 ****
 EEP 66: Sigils for String Literals

--- a/eeps/eep-0067.md
+++ b/eeps/eep-0067.md
@@ -3,7 +3,7 @@
     Status: Rejected
     Type: Standards Track
     Created: 02-Jan-2024
-    Erlang-Version: OTP-27
+    Erlang-Version: OTP-27.0
     Post-History:
 ****
 EEP 67: Internal exports

--- a/eeps/eep-0068.md
+++ b/eeps/eep-0068.md
@@ -1,5 +1,5 @@
     Author: Michał Muskała <micmus(at)whatsapp(dot)com>
-    Status: Final/27.0 Implemented in OTP release 27.0
+    Status: Final/27.0 Implemented in OTP release 27
     Type: Standards Track
     Created: 12-02-2024
     Erlang-Version: OTP-27.0

--- a/eeps/eep-0068.md
+++ b/eeps/eep-0068.md
@@ -2,7 +2,7 @@
     Status: Final/27.0 Implemented in OTP release 27.0
     Type: Standards Track
     Created: 12-02-2024
-    Erlang-Version:
+    Erlang-Version: OTP-27.0
     Post-History: https://github.com/erlang/otp/pull/8111
     Replaces: EEP-0018
 ****

--- a/eeps/eep-0069.md
+++ b/eeps/eep-0069.md
@@ -1,4 +1,4 @@
-    Author: Isabell Huang <isabell.huang@ericsson.com>
+    Author: Isabell Huang <isabell(at)erlang(dot)org>
     Status: Accepted
     Type: Standards Track
     Created: 18-Mar-2024

--- a/eeps/eep-0070.md
+++ b/eeps/eep-0070.md
@@ -1,5 +1,5 @@
     Author: Dániel Szoboszlay <dszoboszlay@gmail.com>
-    Status: Final/28.0 Implemented in OTP version 28.0
+    Status: Final/28.0 Implemented in OTP release 28
     Type: Standards Track
     Created: 01-Jul-2024
     Erlang-Version: OTP-28.0

--- a/eeps/eep-0070.md
+++ b/eeps/eep-0070.md
@@ -2,7 +2,7 @@
     Status: Final/28.0 Implemented in OTP version 28.0
     Type: Standards Track
     Created: 01-Jul-2024
-    Erlang-Version: 28
+    Erlang-Version: OTP-28.0
     Post-History:
         https://erlangforums.com/t/eep-70-non-filtering-generators/3937
         https://github.com/erlang/otp/pull/8625

--- a/eeps/eep-0071.md
+++ b/eeps/eep-0071.md
@@ -1,5 +1,5 @@
     Author: John Högberg <john(at)erlang(dot)org>, Ilya Klyuchnikov <ilya(dot)klyuchnikov(at)gmail(dot)com>
-    Status: Final/28.0 Implemented in OTP version 28.0
+    Status: Final/28.0 Implemented in OTP release 28
     Type: Standards Track
     Created: 7-Aug-2024
     Erlang-Version: OTP-28.0

--- a/eeps/eep-0071.md
+++ b/eeps/eep-0071.md
@@ -2,7 +2,7 @@
     Status: Final/28.0 Implemented in OTP version 28.0
     Type: Standards Track
     Created: 7-Aug-2024
-    Erlang-Version: OTP-28
+    Erlang-Version: OTP-28.0
     Post-History:
         https://erlangforums.com/t/eep-71-clarification-of-type-documentation-and-type-variables/3898
 ****

--- a/eeps/eep-0073.md
+++ b/eeps/eep-0073.md
@@ -2,7 +2,7 @@
     Status: Draft
     Type: Standards Track
     Created: 21-Sep-2024
-    Erlang-Version: 28
+    Erlang-Version: OTP-28.0
     Post-History:
     Replaces: 19
 ****


### PR DESCRIPTION
As the headers in the EEPs are mostly freetext, the contents have diverged depending on author. This PR brings back some consistency and adds some checks so that it will not diverge more in the future.

The checks added are;

1. Erlang-Version must be in the format of an Erlang/OTP version tag and must be present if an EEP is in Final state.
2. Github actions actually check that the current checks are followed.
