### PR TITLE
Update instructions on leaving blank lines

### DIFF
--- a/eeps/eep-0033.md
+++ b/eeps/eep-0033.md
@@ -140,8 +140,8 @@ Acronyms should be in all capitals.
 
 Code samples inside sections should be indented 4 spaces.
 
-You must use three blank lines before all H1 headings, and two before
-all H2 headings.
+Do not leave more than one blank line between paragraphs or before
+headings.
 
 You must adhere to the Emacs convention of adding two spaces at the
 end of every sentence.  You should fill your paragraphs to column 70,


### PR DESCRIPTION
The markdown lint check does not accept multiple blank lines.